### PR TITLE
Repair XDEV builds

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -362,8 +362,7 @@ build_and_install_world() {
 				bin/cat bin/chmod bin/csh bin/echo bin/expr \
 				bin/hostname bin/ln bin/ls bin/mkdir bin/mv \
 				bin/realpath bin/rm bin/rmdir bin/sleep bin/sh \
-				sbin/sha256 sbin/sha512 sbin/sysctl sbin/md5 \
-				sbin/sha1"
+				sbin/sha256 sbin/sha512 sbin/md5 sbin/sha1"
 		for file in ${HLINK_FILES}; do
 			rm -f ${JAILMNT}/${file}
 			sh -c "cd ${JAILMNT} && ln ./nxb-bin/${file} ${file}"


### PR DESCRIPTION
The native-xtools target isn't quite doing the right thing.  I suspect its trying to create amd64 objects when linking.  For now, drop this path changes.  

Repair MIPS64 by using WITH_DEBUG=y.  strip on mips64 corrupts binaries.  This is tested in anger.  :-)
