### PR TITLE
Move .cpignore handling to just the TMPFS_ALL case

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -1570,11 +1570,7 @@ jail_start() {
 	#export CACHESOCK=${MASTERMNT%/ref}/cache.sock
 	#export CACHEPID=${MASTERMNT%/ref}/cache.pid
 	#cached -s ${CACHESOCK} -p ${CACHEPID} -n ${MASTERNAME}
-	echo "src" >> ${mnt}/usr/.cpignore
-	echo "debug" >> ${mnt}/usr/lib/.cpignore
 	clonefs ${mnt} ${tomnt} clean
-	echo ".p" >> ${tomnt}/.cpignore
-	rm -f ${mnt}/usr/.cpignore ${mnt}/usr/lib/.cpignore
 	echo " done"
 
 	if [ ${JAIL_OSVERSION} -gt ${HOST_OSVERSION} ]; then

--- a/src/share/poudriere/include/fs.sh
+++ b/src/share/poudriere/include/fs.sh
@@ -148,7 +148,11 @@ clonefs() {
 			${zfs_to}
 	else
 		[ ${TMPFS_ALL} -eq 1 ] && mnt_tmpfs all ${to}
+		echo "src" >> "$from/usr/.cpignore"
+		echo "debug" >> "$from/usr/lib/.cpignore"
 		do_clone "${from}" "${to}"
+		echo ".p" >> "$to/.cpignore"
+		rm -f "$from/usr/.cpignore" "$from/usr/lib/.cpignore"
 	fi
 }
 


### PR DESCRIPTION
This avoids manipulating .cpignore files in cases where cpdup(1) is not
used. Only this case in clonefs() results in the requirement to have
cpdup-supporting files, and it can be assumed such writes will succeed
when the jail source is on tmpfs.

In particular, this avoids modifying the source jail fs when it is not
the true source, as is the case for zfs sources (which use @clean.)

Signed-off-by: Josh Cepek <josh.cepek@usa.net>