### PR TITLE
Make sure binary exists before remove it

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -372,8 +372,10 @@ build_and_install_world() {
 				bin/realpath bin/rm bin/rmdir bin/sleep bin/sh \
 				sbin/sha256 sbin/sha512 sbin/md5 sbin/sha1"
 		for file in ${HLINK_FILES}; do
-			rm -f ${JAILMNT}/${file}
-			sh -c "cd ${JAILMNT} && ln ./nxb-bin/${file} ${file}"
+			if [ -f "${JAILMNT}/nxb-bin/${file}" ]; then
+				rm -f ${JAILMNT}/${file}
+				sh -c "cd ${JAILMNT} && ln ./nxb-bin/${file} ${file}"
+			fi
 		done
 	fi
 }


### PR DESCRIPTION
I'm making some tests to backport native-xtools to stable/10 and 2 binaries didn't build, I decided to move on for now and make the tests without the static version of them but in the end my jail didn't have the binary at all.

This change checks if file is available inside nxb-bin before remove it from original path.