### PR TITLE
Remove old nxb-bin subdir from jail before copy

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -337,6 +337,7 @@ build_and_install_world() {
 		${MAKE_CMD} -C ${SRC_BASE} native-xtools ${MAKE_JOBS} \
 		    ${MAKEWORLDARGS} NO_SHARED=y || err 1 "Failed to 'make native-xtools'"
 		XDEV_TOOLS=/usr/obj/${TARGET}.${TARGET_ARCH}/nxb-bin
+		[ -d ${JAILMNT}/nxb-bin ] && rm -rf ${JAILMNT}/nxb-bin
 		mv ${XDEV_TOOLS} ${JAILMNT} || err 1 "Failed to move native-xtools"
 		cat >> ${JAILMNT}/etc/make.conf <<- EOF
 		CC=/nxb-bin/usr/bin/cc


### PR DESCRIPTION
If a jail was built using -x, and you try to update it (still using -x), it fails when try to mv nxb-bin from OBJ to jail because the directory already exists there.