### PR TITLE
Implemented 'local' method for ports (uses local ports tree)

### DIFF
--- a/doc/poudriere.8.wiki
+++ b/doc/poudriere.8.wiki
@@ -383,7 +383,7 @@ Gives an alternative <i class="arg">mountpoint</i> when creating ports tree.</dd
 <dt class="list-tag" style="margin-top: 1.00em;">
 <b class="flag">&#45;m</b> <i class="arg">method</i></dt>
 <dd class="list-tag" style="margin-left: 11.00ex;">
-Specifies which <i class="arg">method</i> to use to create the ports tree. Could be portsnap, git, svn{,+http,+https,+file,+ssh} (Default: portsnap).</dd>
+Specifies which <i class="arg">method</i> to use to create the ports tree. Could be portsnap, git, svn{,+http,+https,+file,+ssh}, local (Default: portsnap).</dd>
 <dt class="list-tag" style="margin-top: 1.00em;">
 <b class="flag">&#45;v</b></dt>
 <dd class="list-tag" style="margin-left: 11.00ex;">

--- a/src/bin/poudriere.8
+++ b/src/bin/poudriere.8
@@ -471,7 +471,7 @@ When used with
 specify which
 .Ar method
 to use to create the ports tree.
-Could be portsnap, git, none, svn{,+http,+https,+file,+ssh}.
+Could be portsnap, git, none, svn{,+http,+https,+file,+ssh}, local.
 The default is portsnap.
 .It Fl n
 When combined with

--- a/src/share/poudriere/ports.sh
+++ b/src/share/poudriere/ports.sh
@@ -54,7 +54,7 @@ Options:
     -m method     -- When used with -c, specify the method used to create the
                      ports tree. Possible methods are 'portsnap', 'svn',
                      'svn+http', 'svn+https', 'svn+file', 'svn+ssh', 'git',
-                     or 'none'.
+                     'local', or 'none'.
                      The default is 'portsnap'.
     -n            -- When used with -l, only print the name of the ports tree
     -p name       -- Specifies the name of the ports tree to work on.  The
@@ -140,6 +140,7 @@ svn+ssh);;
 svn+file);;
 svn);;
 git);;
+local);;
 none);;
 *) usage;;
 esac
@@ -235,6 +236,11 @@ if [ ${CREATE} -eq 1 ]; then
 			git clone --depth=1 ${quiet} -b ${BRANCH} ${GIT_URL} ${PTMNT} || err 1 " fail"
 			echo " done"
 			;;
+		local)
+			msg_n "Copying the ports tree..."
+			cp -R /usr/ports/* ${PTMNT} || err 1 " fail"
+ 			echo " done"
+ 			;;
 		esac
 		pset ${PTNAME} method ${METHOD}
 		pset ${PTNAME} timestamp $(date +%s)
@@ -297,6 +303,11 @@ if [ ${UPDATE} -eq 1 ]; then
 		cd ${PORTSMNT:-${PTMNT}} && git pull ${quiet}
 		echo " done"
 		;;
+	local)
+		msg_n "Copying the ports tree..."
+		rm -rf ${PTMNT}/* || err 1 " fail"
+		cp -R /usr/ports/* ${PORTSMNT:-${PTMNT}} || err 1 " fail"
+ 		echo " done"
 	none)	;;
 	*)
 		err 1 "Undefined upgrade method"


### PR DESCRIPTION
This is useful to quickly rebuild packages based on the local ports tree, with local modifications and patches.

Two notes:
* You may want to add the previously added method 'none' to src/bin/poudriere.8 and doc/poudriere.8.wiki
* You may want to add something like || err 1 "fail" after 'git pull' operation in src/share/poudriere/ports.sh