### PR TITLE
Better git support for poudriere

### DIFF
--- a/src/bin/poudriere.8
+++ b/src/bin/poudriere.8
@@ -27,7 +27,7 @@
 .\"
 .\" Note: The date here should be updated whenever a non-trivial
 .\" change is made to the manual page.
-.Dd December 18, 2014
+.Dd March 31, 2015
 .Dt POUDRIERE 8
 .Os
 .Sh NAME
@@ -385,6 +385,13 @@ This will use the
 .Sy SVN_HOST
 variable in
 .Pa poudriere.conf .
+.It Sy git git+file git+ssh git+https git+http
+Use Git.
+Its behavior is configured by the 
+.Fl b 
+and 
+.Fl U 
+options.
 .El
 .It Fl f Ar filesystem
 Specifies the
@@ -408,6 +415,18 @@ as the FreeBSD source tree mounted inside the jail.
 instead of upgrading to the latest security fix of the jail version, you can
 jump to the new specified
 .Ar version .
+.It Fl b Ar branch 
+specify the 
+.Ar branch 
+for
+.Fl m Sy git
+to use.
+.It Fl U Ar url
+specify the
+.Ar url
+for
+.Fl m Sy git 
+to clone from.
 .It Fl z Ar set
 This specifies which SET to start/stop the jail with.
 .It Fl x

--- a/src/bin/poudriere.8
+++ b/src/bin/poudriere.8
@@ -426,7 +426,10 @@ specify the
 .Ar url
 for
 .Fl m Sy git 
-to clone from.
+to clone from, Ex.
+.Bd -literal -offset indent
+-U git@github.com:freebsd/poudriere.git
+.Ed 
 .It Fl z Ar set
 This specifies which SET to start/stop the jail with.
 .It Fl x

--- a/src/bin/poudriere.8
+++ b/src/bin/poudriere.8
@@ -385,10 +385,10 @@ This will use the
 .Sy SVN_HOST
 variable in
 .Pa poudriere.conf .
-.It Sy git git+file git+ssh git+https git+http
+.It Sy git 
 Use Git.
-Its behavior is configured by the 
-.Fl b 
+Its behavior can be configured by the 
+.Fl B 
 and 
 .Fl U 
 options.
@@ -415,20 +415,21 @@ as the FreeBSD source tree mounted inside the jail.
 instead of upgrading to the latest security fix of the jail version, you can
 jump to the new specified
 .Ar version .
-.It Fl b Ar branch 
+.It Fl B Ar branch 
 specify the 
 .Ar branch 
 for
 .Fl m Sy git
 to use.
+Defaults to 'master'.
 .It Fl U Ar url
 specify the
 .Ar url
 for
 .Fl m Sy git 
-to clone from, Ex.
+to clone from, defaults to:
 .Bd -literal -offset indent
--U git@github.com:freebsd/poudriere.git
+git@github.com:freebsd/freebsd.git
 .Ed 
 .It Fl z Ar set
 This specifies which SET to start/stop the jail with.
@@ -483,6 +484,15 @@ The name of the
 to create for the ports tree.
 If 'none' then do not create a filesystem.
 Defaults to poudriere/ports/default.
+.It Fl U Ar url
+specify the
+.Ar url
+for
+.Fl m Sy git
+Defaults to:
+.Bd -literal -offset indent
+git://github.com/freebsd/freebsd-ports.git
+.Ed
 .It Fl k
 When used with
 .Fl d ,

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -4426,6 +4426,7 @@ fi
 : ${PORTBUILD_USER:=nobody}
 : ${BUILD_AS_NON_ROOT:=no}
 : ${SVN_CMD:=$(which svn 2>/dev/null || which svnlite 2>/dev/null)}
+: ${GIT_CMD:=$(which git 2>/dev/null)}
 # 24 hours for 1 command
 : ${MAX_EXECUTION_TIME:=86400}
 # 120 minutes with no log update

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -4285,7 +4285,8 @@ if [ -z "${NO_ZFS}" ]; then
 fi
 
 : ${SVN_HOST="svn0.us-west.freebsd.org"}
-: ${GIT_URL="git://github.com/freebsd/freebsd-ports.git"}
+: ${GIT_PORTS_URL="git://github.com/freebsd/freebsd-ports.git"}
+: ${GIT_JAILS_URL="git://github.com/freebsd/freebsd.git"}
 : ${FREEBSD_HOST="http://ftp.FreeBSD.org"}
 if [ -z "${NO_ZFS}" ]; then
 	: ${ZROOTFS="/poudriere"}

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -183,6 +183,9 @@ rename_jail() {
 update_jail() {
 	SRC_BASE="${JAILMNT}/usr/src"
 	METHOD=$(jget ${JAILNAME} method)
+	SCM_BRANCH=$(jget ${JAILNAME} scm_branch 2>/dev/null)
+	SCM_URL=$(jget ${JAILNAME} scm_url 2>/dev/null)
+	_jget ARCH ${JAILNAME} arch
 	if [ -z "${METHOD}" -o "${METHOD}" = "-" ]; then
 		METHOD="ftp"
 		jset ${JAILNAME} method ${METHOD}
@@ -239,6 +242,15 @@ update_jail() {
 		msg "csup has been deprecated by FreeBSD. Only use if you are syncing with your own csup repo."
 		install_from_csup
 		update_version_env $(jget ${JAILNAME} version)
+		make -C ${SRC_BASE} delete-old delete-old-libs DESTDIR=${JAILMNT} BATCH_DELETE_OLD_FILES=yes
+		markfs clean ${JAILMNT}
+		;;
+	git*)
+		install_from_git version_extra
+		RELEASE=$(update_version "${version_extra}")
+		jset ${JAILNAME} scm_branch "${SCM_BRANCH}"
+		jset ${JAILNAME} scm_url "${SCM_URL}"
+		update_version_env "${RELEASE}"
 		make -C ${SRC_BASE} delete-old delete-old-libs DESTDIR=${JAILMNT} BATCH_DELETE_OLD_FILES=yes
 		markfs clean ${JAILMNT}
 		;;
@@ -426,6 +438,44 @@ install_from_src() {
 
 	setup_compat_env
 	installworld
+}
+
+install_from_git() {
+	local var_version_extra="$1"
+	local UPDATE=0
+	local proto
+	local git_sha
+
+	if [ -d "${SRC_BASE}" ]; then
+		UPDATE=1
+	else
+		mkdir -p ${SRC_BASE}
+	fi
+	case ${METHOD} in
+	git+http) proto="http" ;;
+	git+https) proto="https" ;;
+	git+ssh) proto="git+ssh" ;;
+	git+file) proto="file" ;;
+	git) proto="git" ;;
+	esac
+	if [ ${UPDATE} -eq 0 ]; then
+		msg_n "Checking out the sources using git..."
+		${GIT_CMD} clone ${SCM_BRANCH:+-b ${SCM_BRANCH}}  ${proto}://${SCM_URL} ${SRC_BASE} || err 1 " fail"
+		echo " done"
+		if [ -n "${SRCPATCHFILE}" ]; then
+			msg_n "Patching the sources with ${SRCPATCHFILE}"
+			( cd ${SRC_BASE} && patch -p0 < "${SRCPATCHFILE}") || err 1 " fail"
+			echo done
+		fi
+	else
+		msg_n "Updating the sources from svn..."
+		( cd "${SRC_BASE}" && ${GIT_CMD} pull ) || err 1 " fail"
+		echo " done"
+	fi
+	build_and_install_world
+
+	git_sha=$(${GIT_CMD} git rev-parse --short HEAD)
+	setvar "${var_version_extra}" "${git_sha}"
 }
 
 install_from_svn() {
@@ -642,6 +692,12 @@ create_jail() {
 		IFS=${OIFS}
 		RELEASE="${ALLBSDVER}-JPSNAP/ftp"
 		;;
+	git*)
+		test -z "${GIT_CMD}" && err 1 "You need git on your host to use svn method"
+		test -z "${SCM_BRANCH}" && err 1 "You need to specify an SCM_BRANCH (-b) for git"
+		test -z "${SCM_URL}" && err 1 "You need to specify an SCM_URL (-U) for git"
+		FCT=install_from_git
+		;;
 	svn*)
 		test -z "${SVN_CMD}" && err 1 "You need svn on your host to use svn method"
 		case ${VERSION} in
@@ -715,6 +771,8 @@ create_jail() {
 	# if any error is encountered
 	CLEANUP_HOOK=cleanup_new_jail
 	jset ${JAILNAME} method ${METHOD}
+	[ -n "${SCM_BRANCH}" ] && jset ${JAILNAME} scm_branch ${SCM_BRANCH}
+	[ -n "${SCM_URL}" ] && jset ${JAILNAME} scm_branch ${SCM_URL}
 	[ -n "${FCT}" ] && ${FCT} version_extra
 
 	if [ -r "${SRC_BASE}/sys/conf/newvers.sh" ]; then
@@ -866,7 +924,7 @@ SETNAME=""
 BINMISC="/usr/sbin/binmiscctl"
 XDEV=0
 
-while getopts "iJ:j:v:a:z:m:nf:M:sdklqcip:r:ut:z:P:S:x" FLAG; do
+while getopts "iJ:j:v:a:b:z:m:nf:M:sdklqcip:r:uU:t:z:P:S:x" FLAG; do
 	case "${FLAG}" in
 		i)
 			INFO=1
@@ -885,6 +943,12 @@ while getopts "iJ:j:v:a:z:m:nf:M:sdklqcip:r:ut:z:P:S:x" FLAG; do
 			# If TARGET=TARGET_ARCH trim it away and just use
 			# TARGET_ARCH
 			[ "${ARCH%.*}" = "${ARCH#*.}" ] && ARCH="${ARCH#*.}"
+			;;
+		b)
+			SCM_BRANCH=${OPTARG}
+			;;
+		U)
+			SCM_URL=${OPTARG}
 			;;
 		m)
 			METHOD=${OPTARG}

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -1,4 +1,4 @@
-:!/bin/sh
+#!/bin/sh
 # 
 # Copyright (c) 2010-2013 Baptiste Daroussin <bapt@FreeBSD.org>
 # Copyright (c) 2012-2014 Bryan Drewery <bdrewery@FreeBSD.org>
@@ -688,7 +688,7 @@ create_jail() {
 		;;
 	git)
         test -z "${GIT_CMD}" && err 1 "please install git or specify GIT_CMD"
-        ${GIT_BRANCH:=master}
+        : ${GIT_BRANCH:="master"}
         FCT=install_from_git
 		;;
 	svn*)

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -56,8 +56,8 @@ Options:
                      obtaining and building the jail. See poudriere(8) for more
                      details. Can be one of:
                        allbsd, csup, ftp, http, ftp-archive, null, src, svn,
-                       svn+file, svn+http, svn+https, svn+ssh, git, git+file, 
-                       git+http, git+https, git+ssh, tar=PATH, url=SOMEURL
+                       svn+file, svn+http, svn+https, svn+ssh, git, tar=PATH, 
+                       url=SOMEURL
     -B branch     -- specify branch for -m git
     -U url        -- specify host for -m git
     -P patch      -- Specify a patch to apply to the source before building.

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -474,7 +474,7 @@ install_from_git() {
 	fi
 	build_and_install_world
 
-	git_sha=$(${GIT_CMD} git rev-parse --short HEAD)
+	git_sha=$(${GIT_CMD} rev-parse --short HEAD)
 	setvar "${var_version_extra}" "${git_sha}"
 }
 

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -470,7 +470,7 @@ install_from_git() {
 			echo done
 		fi
 	else
-		msg_n "Updating the sources from svn..."
+		msg_n "Updating the sources from git..."
 		( cd "${SRC_BASE}" && ${GIT_CMD} pull ) || err 1 " fail"
 		echo " done"
 	fi

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+:!/bin/sh
 # 
 # Copyright (c) 2010-2013 Baptiste Daroussin <bapt@FreeBSD.org>
 # Copyright (c) 2012-2014 Bryan Drewery <bdrewery@FreeBSD.org>
@@ -58,7 +58,7 @@ Options:
                        allbsd, csup, ftp, http, ftp-archive, null, src, svn,
                        svn+file, svn+http, svn+https, svn+ssh, git, git+file, 
                        git+http, git+https, git+ssh, tar=PATH, url=SOMEURL
-    -b branch     -- specify branch for -m git
+    -B branch     -- specify branch for -m git
     -U url        -- specify host for -m git
     -P patch      -- Specify a patch to apply to the source before building.
     -S srcpath    -- Specify a path to the source tree to be used.
@@ -186,7 +186,7 @@ update_jail() {
 	SRC_BASE="${JAILMNT}/usr/src"
 	METHOD=$(jget ${JAILNAME} method)
 	GIT_BRANCH=$(jget ${JAILNAME} git_branch 2>/dev/null)
-	GIT_URL=$(jget ${JAILNAME} git_url 2>/dev/null)
+	GIT_JAILS_URL=$(jget ${JAILNAME} git_url 2>/dev/null)
 	_jget ARCH ${JAILNAME} arch
 	if [ -z "${METHOD}" -o "${METHOD}" = "-" ]; then
 		METHOD="ftp"
@@ -251,7 +251,7 @@ update_jail() {
 		install_from_git version_extra
 		RELEASE=$(update_version "${version_extra}")
 		jset ${JAILNAME} git_branch "${GIT_BRANCH}"
-		jset ${JAILNAME} git_url "${GIT_URL}"
+		jset ${JAILNAME} git_url "${GIT_JAILS_URL}"
 		update_version_env "${RELEASE}"
 		make -C ${SRC_BASE} delete-old delete-old-libs DESTDIR=${JAILMNT} BATCH_DELETE_OLD_FILES=yes
 		markfs clean ${JAILMNT}
@@ -454,7 +454,7 @@ install_from_git() {
 	fi
 	if [ ${UPDATE} -eq 0 ]; then
 		msg_n "Checking out the sources using git..."
-		${GIT_CMD} clone --depth 1 ${GIT_BRANCH:+-b ${GIT_BRANCH}}  ${GIT_URL} ${SRC_BASE} || err 1 " fail"
+		${GIT_CMD} clone --depth 1 ${GIT_BRANCH:+-b ${GIT_BRANCH}}  ${GIT_JAILS_URL} ${SRC_BASE} || err 1 " fail"
 		echo " done"
 		if [ -n "${SRCPATCHFILE}" ]; then
 			msg_n "Patching the sources with ${SRCPATCHFILE}"
@@ -765,7 +765,7 @@ create_jail() {
 	CLEANUP_HOOK=cleanup_new_jail
 	jset ${JAILNAME} method ${METHOD}
 	[ -n "${GIT_BRANCH}" ] && jset ${JAILNAME} git_branch ${GIT_BRANCH}
-	[ -n "${GIT_URL}" ] && jset ${JAILNAME} git_url ${GIT_URL}
+	[ -n "${GIT_JAILS_URL}" ] && jset ${JAILNAME} git_url ${GIT_JAILS_URL}
 	[ -n "${FCT}" ] && ${FCT} version_extra
 
 	if [ -r "${SRC_BASE}/sys/conf/newvers.sh" ]; then
@@ -941,7 +941,7 @@ while getopts "iJ:j:v:a:B:z:m:nf:M:sdklqcip:r:uU:t:z:P:S:x" FLAG; do
 			GIT_BRANCH=${OPTARG}
 			;;
 		U)
-			GIT_URL=${OPTARG}
+			GIT_JAILS_URL=${OPTARG}
 			;;
 		m)
 			METHOD=${OPTARG}

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -462,7 +462,7 @@ install_from_git() {
 	esac
 	if [ ${UPDATE} -eq 0 ]; then
 		msg_n "Checking out the sources using git..."
-		${GIT_CMD} clone --depth 1 ${SCM_BRANCH:+-b ${SCM_BRANCH}}  ${proto}://${SCM_URL} ${SRC_BASE} || err 1 " fail"
+		${GIT_CMD} clone --depth 1 ${SCM_BRANCH:+-b ${SCM_BRANCH}}  ${SCM_URL} ${SRC_BASE} || err 1 " fail"
 		echo " done"
 		if [ -n "${SRCPATCHFILE}" ]; then
 			msg_n "Patching the sources with ${SRCPATCHFILE}"

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -56,8 +56,10 @@ Options:
                      obtaining and building the jail. See poudriere(8) for more
                      details. Can be one of:
                        allbsd, csup, ftp, http, ftp-archive, null, src, svn,
-                       svn+file, svn+http, svn+https, svn+ssh, tar=PATH
-                       url=SOMEURL
+                       svn+file, svn+http, svn+https, svn+ssh, git, git+file, 
+                       git+http, git+https, git+ssh, tar=PATH, url=SOMEURL
+    -b branch     -- specify branch for -m git
+    -U url        -- specify host for -m git
     -P patch      -- Specify a patch to apply to the source before building.
     -S srcpath    -- Specify a path to the source tree to be used.
     -t version    -- Version of FreeBSD to upgrade the jail to.

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -774,7 +774,7 @@ create_jail() {
 	CLEANUP_HOOK=cleanup_new_jail
 	jset ${JAILNAME} method ${METHOD}
 	[ -n "${SCM_BRANCH}" ] && jset ${JAILNAME} scm_branch ${SCM_BRANCH}
-	[ -n "${SCM_URL}" ] && jset ${JAILNAME} scm_branch ${SCM_URL}
+	[ -n "${SCM_URL}" ] && jset ${JAILNAME} scm_url ${SCM_URL}
 	[ -n "${FCT}" ] && ${FCT} version_extra
 
 	if [ -r "${SRC_BASE}/sys/conf/newvers.sh" ]; then

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -460,7 +460,7 @@ install_from_git() {
 	esac
 	if [ ${UPDATE} -eq 0 ]; then
 		msg_n "Checking out the sources using git..."
-		${GIT_CMD} clone ${SCM_BRANCH:+-b ${SCM_BRANCH}}  ${proto}://${SCM_URL} ${SRC_BASE} || err 1 " fail"
+		${GIT_CMD} clone --depth 1 ${SCM_BRANCH:+-b ${SCM_BRANCH}}  ${proto}://${SCM_URL} ${SRC_BASE} || err 1 " fail"
 		echo " done"
 		if [ -n "${SRCPATCHFILE}" ]; then
 			msg_n "Patching the sources with ${SRCPATCHFILE}"

--- a/src/share/poudriere/ports.sh
+++ b/src/share/poudriere/ports.sh
@@ -115,6 +115,9 @@ while getopts "B:cFudklp:qf:nM:m:v" FLAG; do
 		m)
 			METHOD=${OPTARG}
 			;;
+        U)
+            GIT_URL=${OPTARG}
+            ;;
 		v)
 			VERBOSE=$((${VERBOSE} + 1))
 			;;

--- a/src/share/poudriere/ports.sh
+++ b/src/share/poudriere/ports.sh
@@ -116,7 +116,7 @@ while getopts "B:cFudklp:qf:nM:m:v" FLAG; do
 			METHOD=${OPTARG}
 			;;
         U)
-            GIT_URL=${OPTARG}
+            GIT_PORTS_URL=${OPTARG}
             ;;
 		v)
 			VERBOSE=$((${VERBOSE} + 1))
@@ -235,7 +235,7 @@ if [ ${CREATE} -eq 1 ]; then
 		git)
 			msg_n "Cloning the ports tree..."
 			[ ${VERBOSE} -gt 0 ] || quiet="-q"
-			git clone --depth=1 ${quiet} -b ${BRANCH} ${GIT_URL} ${PTMNT} || err 1 " fail"
+			git clone --depth=1 ${quiet} -b ${BRANCH} ${GIT_PORTS_URL} ${PTMNT} || err 1 " fail"
 			echo " done"
 			;;
 		esac
@@ -286,7 +286,7 @@ if [ ${UPDATE} -eq 1 ]; then
 		/usr/sbin/portsnap ${PTARGS} -d ${SNAPDIR} -p ${PORTSMNT:-${PTMNT}} ${PSCOMMAND} alfred
 		;;
 	svn*)
-		msg_n "Updating the ports tree..."
+		msg_n "Updating the ports tree from svn..."
 		[ ${VERBOSE} -gt 0 ] || quiet="-q"
 		${SVN_CMD} upgrade ${PORTSMNT:-${PTMNT}} 2>/dev/null || :
 		${SVN_CMD} ${quiet} update \
@@ -295,7 +295,7 @@ if [ ${UPDATE} -eq 1 ]; then
 		echo " done"
 		;;
 	git)
-		msg "Pulling from ${GIT_URL}"
+		msg "Updating ports tree from git..."
 		[ ${VERBOSE} -gt 0 ] || quiet="-q"
 		cd ${PORTSMNT:-${PTMNT}} && git pull ${quiet}
 		echo " done"

--- a/src/share/poudriere/ports.sh
+++ b/src/share/poudriere/ports.sh
@@ -75,7 +75,7 @@ NAMEONLY=0
 QUIET=0
 VERBOSE=0
 KEEP=0
-while getopts "B:cFudklp:qf:nM:m:v:U" FLAG; do
+while getopts "B:cFudklp:qf:nM:m:U:v" FLAG; do
 	case "${FLAG}" in
 		B)
 			BRANCH="${OPTARG}"
@@ -116,9 +116,10 @@ while getopts "B:cFudklp:qf:nM:m:v:U" FLAG; do
 		m)
 			METHOD=${OPTARG}
 			;;
-        U)
-            GIT_PORTS_URL=${OPTARG}
-            ;;
+        	U)
+			msg "setting git ports url to ${OPTARG}"
+            		GIT_PORTS_URL=${OPTARG}
+            		;;
 		v)
 			VERBOSE=$((${VERBOSE} + 1))
 			;;

--- a/src/share/poudriere/ports.sh
+++ b/src/share/poudriere/ports.sh
@@ -43,6 +43,7 @@ Parameters:
 Options:
     -B branch     -- Which branch to use for the svn or git methods.  Defaults
                      to 'head/master'.
+    -U url        -- specify the host to use for the git method
     -F            -- When used with -c, only create the needed filesystems
                      (for ZFS) and directories, but do not populate them.
     -M path       -- The path to the source of a ports tree.
@@ -74,7 +75,7 @@ NAMEONLY=0
 QUIET=0
 VERBOSE=0
 KEEP=0
-while getopts "B:cFudklp:qf:nM:m:v" FLAG; do
+while getopts "B:cFudklp:qf:nM:m:v:U" FLAG; do
 	case "${FLAG}" in
 		B)
 			BRANCH="${OPTARG}"


### PR DESCRIPTION
allows users to specify git urls for poudriere ports command, and adds equivalent git support to the poudriere jail command.  Based on splbio's 3.1.1-git fork.

Sponsored by:  Norse Corp