### PR TITLE
fix for issue created by allowing periods in port tree name

### DIFF
--- a/src/share/poudriere/ports.sh
+++ b/src/share/poudriere/ports.sh
@@ -199,6 +199,8 @@ if [ ${CREATE} -eq 1 ]; then
 	# if any error is encountered
 	CLEANUP_HOOK=cleanup_new_ports
 
+	[ "${PTNAME#*.*}" = "${PTNAME}" ] ||
+		err 1 "The ports name can not contain a period (.). See jail(8)"
 	createfs ${PTNAME} ${PTMNT} ${PTFS}
 	pset ${PTNAME} mnt ${PTMNT}
 	if [ $FAKE -eq 0 ]; then


### PR DESCRIPTION
Fixes a bug which causes poudriere to try and create a jail with a period in it

Sponsored By:  Norse Corp