### PR TITLE
Implement hooks for ports, adjust sample syntax for www/apache24

### DIFF
--- a/src/etc/poudriere.d/hooks/ports.sh.sample
+++ b/src/etc/poudriere.d/hooks/ports.sh.sample
@@ -1,0 +1,38 @@
+#!/bin/sh
+# /usr/local/etc/poudriere.d/hooks/ports.sh
+#
+# Author: Emanuel Haupt <ehaupt@FreeBSD.org>
+#
+# This hook makes sure the updated/created ports tree is always pristine and
+# hasn't been tampered with or hasn't been modified otherwise by maintaining zfs
+# filesystem snapshots of the created ports trees.
+
+status="$1"
+shift
+
+mountpoint="$1"
+
+zfs_vol="$(df ${mountpoint} | tail -1 | awk '{print $1}')"
+
+case ${status} in
+	create_done)
+		if [ "$2" = "success" ]; then
+			zfs snapshot ${zfs_vol}@clean
+		fi
+	;;
+
+	update_start)
+		zfs rollback ${zfs_vol}@clean 2>/dev/null || :
+	;;
+
+	update_stop)
+		zfs destroy -r ${zfs_vol}@clean 2>/dev/null || :
+		zfs snapshot ${zfs_vol}@clean
+	;;
+
+	*)
+		echo "Unknown status!"
+	;;
+esac
+
+exit 0

--- a/src/share/examples/poudriere/httpd.conf.sample
+++ b/src/share/examples/poudriere/httpd.conf.sample
@@ -3,6 +3,6 @@ Alias /poudriere/data "/usr/local/poudriere/data/logs/bulk"
 Alias /poudriere "/usr/local/share/poudriere/html"
 
 <Location /poudriere>
-        Allow from all
-        Options Indexes
+	Require all granted
+	Options Indexes
 </Location>


### PR DESCRIPTION
Implement some hooks to be used after creation/updating of a ports tree and provide a sample script that makes sure the updated/created ports tree is always pristine and hasn't been tampered with or hasn't been modified otherwise. This is done by maintaining zfs filesystem snapshots of the created/updated ports tree.
