### PR TITLE
xhtml support

### DIFF
--- a/src/share/poudriere/html/assets/poudriere.js
+++ b/src/share/poudriere/html/assets/poudriere.js
@@ -268,7 +268,7 @@ function build_url(mastername, buildname) {
 		return '';
 	}
 	return 'build.html?' +
-		'mastername=' + encodeURIComponent(mastername) + '&' +
+		'mastername=' + encodeURIComponent(mastername) + '&amp;' +
 		'build=' + encodeURIComponent(buildname);
 }
 
@@ -1091,7 +1091,7 @@ function setup_index() {
 	table.rowGrouping({
 		iGroupingColumnIndex2: 4,
 		iGroupingColumnIndex: 5,
-		sGroupLabelPrefix2: "&nbsp;&nbsp;Set - ",
+		sGroupLabelPrefix2: "&#160;;&#160;Set - ",
 		sGroupLabelPrefix: "Ports - ",
 		sEmptyGroupLabel: "",
 		fnGroupLabelFormat: function(label) {

--- a/src/share/poudriere/html/build.html
+++ b/src/share/poudriere/html/build.html
@@ -1,19 +1,19 @@
 <!DOCTYPE html>
-<html lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 	<head>
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="Cache-Control" content="no-cache">
-		<meta http-equiv="Pragma" content="no-cache">
-		<meta http-equiv="Expires" content="0">
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta http-equiv="Cache-Control" content="no-cache" />
+		<meta http-equiv="Pragma" content="no-cache" />
+		<meta http-equiv="Expires" content="0" />
 
 		<title>Poudriere bulk results</title>
 
-		<link href="assets/DataTables-1.10.0/css/jquery.dataTables.min.css" rel="stylesheet" type="text/css">
+		<link href="assets/DataTables-1.10.0/css/jquery.dataTables.min.css" rel="stylesheet" type="text/css" />
 		<link href="assets/bootstrap-3.1.1/css/bootstrap.min.css" type="text/css" rel="stylesheet" />
 		<link href="assets/poudriere.css" type="text/css" rel="stylesheet" />
 
-		<link rel="shortcut icon" href="assets/favicon.ico">
+		<link rel="shortcut icon" href="assets/favicon.ico" />
 	</head>
 	<body>
 		<div id="top"></div>
@@ -91,7 +91,7 @@
 													</tr>
 												</thead>
 												<tr>
-													<td id="snap_loadavg" title="(% of allocated CPU) 1 5 10 minute averages" id="snap_loadavg"></td>
+													<td id="snap_loadavg" title="(% of allocated CPU) 1 5 10 minute averages"></td>
 													<td id="snap_swapinfo" title="% of swap devices used"></td>
 													<td id="snap_elapsed"></td>
 													<td id="snap_pkghour" title="Average package build rate per hour"></td>
@@ -106,152 +106,151 @@
 					</div><!-- /col -->
 				</div><!-- /row -->
 			</div><!-- /container -->
-		</div> <!-- navbar-static-top -->
-	</div><!-- #header, navbar -->
-	<div id="main" class="container-fluid">
-		<div id="loading_overlay">
-			<div id="loading">
-				<p>Loading...</p>
+		</div><!-- #header, navbar -->
+		<div id="main" class="container-fluid">
+			<div id="loading_overlay">
+				<div id="loading">
+					<p>Loading...</p>
+				</div>
 			</div>
-		</div>
-		<div class="row">
-			<div class="col-md-5">
-				<div id="build_info_div" style="display: none;">
-					<h2 id="build_info">Build
-						<a href="#"><span class="top-icon glyphicon glyphicon-chevron-up"></span></a>
-					</h2>
-					<dl class="dl-horizontal">
-						<dt>Master</dt>
-						<dd id="mastername"></dd>
-						<dt>Build</dt>
-						<dd id="buildname"></dd>
-						<dt>Status</dt>
-						<dd id="status"></dd>
-						<dt>Jail</dt>
-						<dd id="jail"></dd>
-						<dt>Set</dt>
-						<dd id="setname"></dd>
-						<dt>Ports Tree</dt>
-						<dd id="ptname"></dd>
-						<dt>SVN</dt>
-						<dd id="svn_url"></dd>
-					</dl>
-				</div><!-- #build_info -->
-			</div><!-- /col -->
-			<div class="col-md-7">
-				<div id="jobs_div" class="status" style="display: none;">
-					<h2 id="jobs">Jobs
-						<a href="#"><span class="top-icon glyphicon glyphicon-chevron-up"></span></a>
-					</h2>
-					<table id="builders_table" class="display" style="">
-						<thead>
-							<tr>
-								<th>Id</th>
-								<th>Origin</th>
-								<th>Status</th>
-								<th>Elapsed</th>
-							</tr>
-						</thead>
-						<tbody id="builders_body"></tbody>
-					</table>
-				</div><!-- #jobs -->
-			</div><!-- /col -->
-		</div><!-- /row -->
-		<div class="row">
-			<div class="col-md-12">
-				<div id="built_div" class="status" style="display: none;">
-					<h2 id="built">Built ports
-						<a href="#"><span class="top-icon glyphicon glyphicon-chevron-up"></span></a>
-					</h2>
-					<table class="display built ports table-bordered" id="built_table">
-						<thead>
-							<tr>
-								<th>#</th>
-								<th>Package</th>
-								<th>Origin</th>
-								<th>Log</th>
-							</tr>
-						</thead>
-						<tbody id="built_body"></tbody>
-					</table>
-				</div><!-- #built -->
-				<div id="failed_div" class="status" style="display: none;">
-					<h2 id="failed">Failed ports
-						<a href="#"><span class="top-icon glyphicon glyphicon-chevron-up"></span></a>
-					</h2>
-					<table class="display failed ports table-bordered" id="failed_table">
-						<thead>
-							<tr>
-								<th>#</th>
-								<th>Package</th>
-								<th>Origin</th>
-								<th>Phase</th>
-								<th>Skipped</th>
-								<th>Log</th>
-							</tr>
-						</thead>
-						<tbody id="failed_body"></tbody>
-					</table>
-				</div><!-- #failed -->
-				<div id="skipped_div" class="status" style="display: none;">
-					<h2 id="skipped">Skipped ports
-						<a href="#"><span class="top-icon glyphicon glyphicon-chevron-up"></span></a>
-					</h2>
-					<table class="display skipped ports table-bordered" id="skipped_table">
-						<thead>
-							<tr>
-								<th>#</th>
-								<th>Package</th>
-								<th>Origin</th>
-								<th>Reason</th>
-							</tr>
-						</thead>
-						<tbody id="skipped_body"></tbody>
-					</table>
-				</div><!-- #skipped -->
-				<div id="ignored_div" class="status" style="display: none;">
-					<h2 id="ignored">Ignored ports
-						<a href="#"><span class="top-icon glyphicon glyphicon-chevron-up"></span></a>
-					</h2>
-					<table class="display ignored ports table-bordered" id="ignored_table">
-						<thead>
-							<tr>
-								<th>#</th>
-								<th>Package</th>
-								<th>Origin</th>
-								<th>Skipped</th>
-								<th>Reason</th>
-							</tr>
-						</thead>
-						<tbody id="ignored_body"></tbody>
-					</table>
-				</div><!-- #ignored -->
-				<br class="clear" />
-			</div><!-- /col -->
-		</div><!-- /row -->
-	</div><!-- #main -->
-	<br class="clear" />
-	<footer class="navbar-fixed-bottom">
-		<div class="container-fluid">
 			<div class="row">
-				<div class="col-md-10 col-sm-9 col-xs-9" id="progress_col">
-					<span id="progress">
-						<canvas id="progressbar"></canvas>
-						<span id="progresspct"></span>
-					</span>
+				<div class="col-md-5">
+					<div id="build_info_div" style="display: none;">
+						<h2 id="build_info">Build
+							<a href="#"><span class="top-icon glyphicon glyphicon-chevron-up"></span></a>
+						</h2>
+						<dl class="dl-horizontal">
+							<dt>Master</dt>
+							<dd id="mastername"></dd>
+							<dt>Build</dt>
+							<dd id="buildname"></dd>
+							<dt>Status</dt>
+							<dd id="status"></dd>
+							<dt>Jail</dt>
+							<dd id="jail"></dd>
+							<dt>Set</dt>
+							<dd id="setname"></dd>
+							<dt>Ports Tree</dt>
+							<dd id="ptname"></dd>
+							<dt>SVN</dt>
+							<dd id="svn_url"></dd>
+						</dl>
+					</div><!-- #build_info -->
 				</div><!-- /col -->
-				<div class="col-md-2 col-sm-3 col-xs-3">
-					<a class="pull-right" target="_new" href="http://fossil.etoilebsd.net/poudriere"><span class="glyphicon glyphicon-share-alt"></span>Poudriere</a>
+				<div class="col-md-7">
+					<div id="jobs_div" class="status" style="display: none;">
+						<h2 id="jobs">Jobs
+							<a href="#"><span class="top-icon glyphicon glyphicon-chevron-up"></span></a>
+						</h2>
+						<table id="builders_table" class="display" style="">
+							<thead>
+								<tr>
+									<th>Id</th>
+									<th>Origin</th>
+									<th>Status</th>
+									<th>Elapsed</th>
+								</tr>
+							</thead>
+							<tbody id="builders_body"></tbody>
+						</table>
+					</div><!-- #jobs -->
 				</div><!-- /col -->
 			</div><!-- /row -->
-		</div><!-- /container-fluid -->
-	</footer><!-- #footer -->
-	<script src="assets/jquery-1.11.1.min.js" type="text/javascript"></script>
-	<script src="assets/DataTables-1.10.0/js/jquery.dataTables.min.js" type="text/javascript" charset="utf8"></script>
-	<script src="assets/bootstrap-3.1.1/js/bootstrap.min.js" type="text/javascript"></script>
-	<script src="assets/jquery.dataTables.rowGrouping-1.2.9.js" type="text/javascript"></script>
-	<script type="text/javascript">server_style = "hosted";</script>
-	<script src="assets/poudriere.js" type="text/javascript"></script>
-</body>
+			<div class="row">
+				<div class="col-md-12">
+					<div id="built_div" class="status" style="display: none;">
+						<h2 id="built">Built ports
+							<a href="#"><span class="top-icon glyphicon glyphicon-chevron-up"></span></a>
+						</h2>
+						<table class="display built ports table-bordered" id="built_table">
+							<thead>
+								<tr>
+									<th>#</th>
+									<th>Package</th>
+									<th>Origin</th>
+									<th>Log</th>
+								</tr>
+							</thead>
+							<tbody id="built_body"></tbody>
+						</table>
+					</div><!-- #built -->
+					<div id="failed_div" class="status" style="display: none;">
+						<h2 id="failed">Failed ports
+							<a href="#"><span class="top-icon glyphicon glyphicon-chevron-up"></span></a>
+						</h2>
+						<table class="display failed ports table-bordered" id="failed_table">
+							<thead>
+								<tr>
+									<th>#</th>
+									<th>Package</th>
+									<th>Origin</th>
+									<th>Phase</th>
+									<th>Skipped</th>
+									<th>Log</th>
+								</tr>
+							</thead>
+							<tbody id="failed_body"></tbody>
+						</table>
+					</div><!-- #failed -->
+					<div id="skipped_div" class="status" style="display: none;">
+						<h2 id="skipped">Skipped ports
+							<a href="#"><span class="top-icon glyphicon glyphicon-chevron-up"></span></a>
+						</h2>
+						<table class="display skipped ports table-bordered" id="skipped_table">
+							<thead>
+								<tr>
+									<th>#</th>
+									<th>Package</th>
+									<th>Origin</th>
+									<th>Reason</th>
+								</tr>
+							</thead>
+							<tbody id="skipped_body"></tbody>
+						</table>
+					</div><!-- #skipped -->
+					<div id="ignored_div" class="status" style="display: none;">
+						<h2 id="ignored">Ignored ports
+							<a href="#"><span class="top-icon glyphicon glyphicon-chevron-up"></span></a>
+						</h2>
+						<table class="display ignored ports table-bordered" id="ignored_table">
+							<thead>
+								<tr>
+									<th>#</th>
+									<th>Package</th>
+									<th>Origin</th>
+									<th>Skipped</th>
+									<th>Reason</th>
+								</tr>
+							</thead>
+							<tbody id="ignored_body"></tbody>
+						</table>
+					</div><!-- #ignored -->
+					<br class="clear" />
+				</div><!-- /col -->
+			</div><!-- /row -->
+		</div><!-- #main -->
+		<br class="clear" />
+		<footer class="navbar-fixed-bottom">
+			<div class="container-fluid">
+				<div class="row">
+					<div class="col-md-10 col-sm-9 col-xs-9" id="progress_col">
+						<span id="progress">
+							<canvas id="progressbar"></canvas>
+							<span id="progresspct"></span>
+						</span>
+					</div><!-- /col -->
+					<div class="col-md-2 col-sm-3 col-xs-3">
+						<a class="pull-right" target="_new" href="http://fossil.etoilebsd.net/poudriere"><span class="glyphicon glyphicon-share-alt"></span>Poudriere</a>
+					</div><!-- /col -->
+				</div><!-- /row -->
+			</div><!-- /container-fluid -->
+		</footer><!-- #footer -->
+		<script src="assets/jquery-1.11.1.min.js" type="text/javascript"></script>
+		<script src="assets/DataTables-1.10.0/js/jquery.dataTables.min.js" type="text/javascript" charset="utf8"></script>
+		<script src="assets/bootstrap-3.1.1/js/bootstrap.min.js" type="text/javascript"></script>
+		<script src="assets/jquery.dataTables.rowGrouping-1.2.9.js" type="text/javascript"></script>
+		<script type="text/javascript">server_style = "hosted";</script>
+		<script src="assets/poudriere.js" type="text/javascript"></script>
+	</body>
 </html>
 <!-- vim: set sts=4 sw=4 ts=4 noet: -->

--- a/src/share/poudriere/html/index.html
+++ b/src/share/poudriere/html/index.html
@@ -1,19 +1,19 @@
 <!DOCTYPE html>
-<html lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 	<head>
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="Cache-Control" content="no-cache">
-		<meta http-equiv="Pragma" content="no-cache">
-		<meta http-equiv="Expires" content="0">
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta http-equiv="Cache-Control" content="no-cache" />
+		<meta http-equiv="Pragma" content="no-cache" />
+		<meta http-equiv="Expires" content="0" />
 
 		<title>Poudriere Index</title>
 
-		<link href="assets/DataTables-1.10.0/css/jquery.dataTables.min.css" rel="stylesheet" type="text/css">
+		<link href="assets/DataTables-1.10.0/css/jquery.dataTables.min.css" rel="stylesheet" type="text/css" />
 		<link href="assets/bootstrap-3.1.1/css/bootstrap.min.css" type="text/css" rel="stylesheet" />
 		<link href="assets/poudriere.css" type="text/css" rel="stylesheet" />
 
-		<link rel="shortcut icon" href="assets/favicon.ico">
+		<link rel="shortcut icon" href="assets/favicon.ico" />
 	</head>
 	<body>
 		<div id="top"></div>
@@ -39,62 +39,61 @@
 					</div><!-- /col -->
 				</div><!-- /row -->
 			</div><!-- /container -->
-		</div> <!-- navbar-static-top -->
-	</div><!-- #header, navbar -->
-	<div id="main" class="container-fluid">
-		<div id="loading_overlay">
-			<div id="loading">
-				<p>Loading...</p>
+		</div><!-- #header, navbar -->
+		<div id="main" class="container-fluid">
+			<div id="loading_overlay">
+				<div id="loading">
+					<p>Loading...</p>
+				</div>
 			</div>
-		</div>
-		<div class="row">
-			<div class="col-md-12">
-				<div id="latest_builds_div" class="status" style="display: none;">
-					<h2 id="latest_builds">Latest Builds
-						<a href="#"><span class="top-icon glyphicon glyphicon-chevron-up"></span></a>
-					</h2>
-					<table class="display latest_builds table-bordered" id="latest_builds_table">
-						<thead>
-							<tr>
-								<th>Portset</th>
-								<th>Master</th>
-								<th>Build</th>
-								<th>Jail</th>
-								<th>Set</th>
-								<th>Ports</th>
-								<th class="queued" title="Queued" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Queued</span><span class="hidden-md hidden-lg">Q</th>
-								<th class="built" title="Built" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Built</span><span class="hidden-md hidden-lg">B</th>
-								<th class="failed" title="Failed" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Failed</span><span class="hidden-md hidden-lg">F</th>
-								<th class="skipped" title="Skipped" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Skipped</span><span class="hidden-md hidden-lg">S</th>
-								<th class="ignored" title="Ignored" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Ignored</span><span class="hidden-md hidden-lg">I</th>
-								<th class="remaining" title="Remaining" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Remaining</span><span class="hidden-md hidden-lg">R</th>
-								<th>Status</th>
-								<th>Elapsed</th>
-							</tr>
-						</thead>
-						<tbody id="latest_builds_body"></tbody>
-					</table>
-				</div><!-- #latest_builds -->
-				<br class="clear" />
-			</div><!-- /col -->
-		</div><!-- /row -->
-	</div><!-- #main -->
-	<br class="clear" />
-	<footer class="navbar-fixed-bottom">
-		<div class="container-fluid">
 			<div class="row">
 				<div class="col-md-12">
-					<a class="pull-right" target="_new" href="http://fossil.etoilebsd.net/poudriere"><span class="glyphicon glyphicon-share-alt"></span>Poudriere</a>
+					<div id="latest_builds_div" class="status" style="display: none;">
+						<h2 id="latest_builds">Latest Builds
+							<a href="#"><span class="top-icon glyphicon glyphicon-chevron-up"></span></a>
+						</h2>
+						<table class="display latest_builds table-bordered" id="latest_builds_table">
+							<thead>
+								<tr>
+									<th>Portset</th>
+									<th>Master</th>
+									<th>Build</th>
+									<th>Jail</th>
+									<th>Set</th>
+									<th>Ports</th>
+									<th class="queued" title="Queued" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Queued</span><span class="hidden-md hidden-lg">Q</span></th>
+									<th class="built" title="Built" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Built</span><span class="hidden-md hidden-lg">Bi</span></th>
+									<th class="failed" title="Failed" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Failed</span><span class="hidden-md hidden-lg">F</span></th>
+									<th class="skipped" title="Skipped" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Skipped</span><span class="hidden-md hidden-lg">S</span></th>
+									<th class="ignored" title="Ignored" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Ignored</span><span class="hidden-md hidden-lg">I</span></th>
+									<th class="remaining" title="Remaining" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Remaining</span><span class="hidden-md hidden-lg">R</span></th>
+									<th>Status</th>
+									<th>Elapsed</th>
+								</tr>
+							</thead>
+							<tbody id="latest_builds_body"></tbody>
+						</table>
+					</div><!-- #latest_builds -->
+					<br class="clear" />
 				</div><!-- /col -->
 			</div><!-- /row -->
-		</div><!-- /container-fluid -->
-	</footer><!-- #footer -->
-	<script src="assets/jquery-1.11.1.min.js" type="text/javascript"></script>
-	<script src="assets/DataTables-1.10.0/js/jquery.dataTables.min.js" type="text/javascript" charset="utf8"></script>
-	<script src="assets/bootstrap-3.1.1/js/bootstrap.min.js" type="text/javascript"></script>
-	<script src="assets/jquery.dataTables.rowGrouping-1.2.9.js" type="text/javascript"></script>
-	<script type="text/javascript">server_style = "hosted";</script>
-	<script src="assets/poudriere.js" type="text/javascript"></script>
-</body>
+		</div><!-- #main -->
+		<br class="clear" />
+		<footer class="navbar-fixed-bottom">
+			<div class="container-fluid">
+				<div class="row">
+					<div class="col-md-12">
+						<a class="pull-right" target="_new" href="http://fossil.etoilebsd.net/poudriere"><span class="glyphicon glyphicon-share-alt"></span>Poudriere</a>
+					</div><!-- /col -->
+				</div><!-- /row -->
+			</div><!-- /container-fluid -->
+		</footer><!-- #footer -->
+		<script src="assets/jquery-1.11.1.min.js" type="text/javascript"></script>
+		<script src="assets/DataTables-1.10.0/js/jquery.dataTables.min.js" type="text/javascript" charset="utf8"></script>
+		<script src="assets/bootstrap-3.1.1/js/bootstrap.min.js" type="text/javascript"></script>
+		<script src="assets/jquery.dataTables.rowGrouping-1.2.9.js" type="text/javascript"></script>
+		<script type="text/javascript">server_style = "inline";</script>
+		<script src="assets/poudriere.js" type="text/javascript"></script>
+	</body>
 </html>
 <!-- vim: set sts=4 sw=4 ts=4 noet: -->

--- a/src/share/poudriere/html/jail.html
+++ b/src/share/poudriere/html/jail.html
@@ -1,19 +1,19 @@
 <!DOCTYPE html>
-<html lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 	<head>
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="Cache-Control" content="no-cache">
-		<meta http-equiv="Pragma" content="no-cache">
-		<meta http-equiv="Expires" content="0">
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta http-equiv="Cache-Control" content="no-cache" />
+		<meta http-equiv="Pragma" content="no-cache" />
+		<meta http-equiv="Expires" content="0" />
 
 		<title>Poudriere Jail listing</title>
 
-		<link href="assets/DataTables-1.10.0/css/jquery.dataTables.min.css" rel="stylesheet" type="text/css">
+		<link href="assets/DataTables-1.10.0/css/jquery.dataTables.min.css" rel="stylesheet" type="text/css" />
 		<link href="assets/bootstrap-3.1.1/css/bootstrap.min.css" type="text/css" rel="stylesheet" />
 		<link href="assets/poudriere.css" type="text/css" rel="stylesheet" />
 
-		<link rel="shortcut icon" href="assets/favicon.ico">
+		<link rel="shortcut icon" href="assets/favicon.ico" />
 	</head>
 	<body>
 		<div id="top"></div>
@@ -42,80 +42,79 @@
 					</div><!-- /col -->
 				</div><!-- /row -->
 			</div><!-- /container -->
-		</div> <!-- navbar-static-top -->
-	</div><!-- #header, navbar -->
-	<div id="main" class="container-fluid">
-		<div id="loading_overlay">
-			<div id="loading">
-				<p>Loading...</p>
+		</div><!-- #header, navbar -->
+		<div id="main" class="container-fluid">
+			<div id="loading_overlay">
+				<div id="loading">
+					<p>Loading...</p>
+				</div>
 			</div>
-		</div>
-		<div class="row">
-			<div class="col-md-12">
-				<div id="masterinfo_div" class="status" style="display: none;">
-					<h2 id="masterinfo">Master Info
-						<a href="#"><span class="top-icon glyphicon glyphicon-chevron-up"></span></a>
-					</h2>
-					<dl class="dl-horizontal">
-						<dt>Master</dt>
-						<dd id="mastername"></dd>
-						<dt>Latest build</dt>
-						<dd id="latest_build"></dd>
-						<dt>Status</dt>
-						<dd id="status"></dd>
-						<dt>Jail</dt>
-						<dd id="jail"></dd>
-						<dt>Set</dt>
-						<dd id="setname"></dd>
-						<dt>Ports Tree</dt>
-						<dd id="ptname"></dd>
-					</dl>
-				</div><!-- #masterinfo -->
-			</div><!-- /col -->
-		</div><!-- /row -->
-		<div class="row">
-			<div class="col-md-12">
-				<div id="builds_div" class="status" style="display: none;">
-					<h2 id="builds">Builds
-						<a href="#"><span class="top-icon glyphicon glyphicon-chevron-up"></span></a>
-					</h2>
-					<table class="display builds table-bordered" id="builds_table">
-						<thead>
-							<tr>
-								<th>Build</th>
-								<th class="queued" title="Queued" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Queued</span><span class="hidden-md hidden-lg">Q</th>
-								<th class="built" title="Built" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Built</span><span class="hidden-md hidden-lg">B</th>
-								<th class="failed" title="Failed" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Failed</span><span class="hidden-md hidden-lg">F</th>
-								<th class="skipped" title="Skipped" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Skipped</span><span class="hidden-md hidden-lg">S</th>
-								<th class="ignored" title="Ignored" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Ignored</span><span class="hidden-md hidden-lg">I</th>
-								<th class="remaining" title="Remaining" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Remaining</span><span class="hidden-md hidden-lg">R</th>
-								<th>Status</th>
-								<th>Elapsed</th>
-							</tr>
-						</thead>
-						<tbody id="builds_body"></tbody>
-					</table>
-				</div><!-- #builds -->
-				<br class="clear" />
-			</div><!-- /col -->
-		</div><!-- /row -->
-	</div><!-- #main -->
-	<br class="clear" />
-	<footer class="navbar-fixed-bottom">
-		<div class="container-fluid">
 			<div class="row">
 				<div class="col-md-12">
-					<a class="pull-right" target="_new" href="http://fossil.etoilebsd.net/poudriere"><span class="glyphicon glyphicon-share-alt"></span>Poudriere</a>
+					<div id="masterinfo_div" class="status" style="display: none;">
+						<h2 id="masterinfo">Master Info
+							<a href="#"><span class="top-icon glyphicon glyphicon-chevron-up"></span></a>
+						</h2>
+						<dl class="dl-horizontal">
+							<dt>Master</dt>
+							<dd id="mastername"></dd>
+							<dt>Latest build</dt>
+							<dd id="latest_build"></dd>
+							<dt>Status</dt>
+							<dd id="status"></dd>
+							<dt>Jail</dt>
+							<dd id="jail"></dd>
+							<dt>Set</dt>
+							<dd id="setname"></dd>
+							<dt>Ports Tree</dt>
+							<dd id="ptname"></dd>
+						</dl>
+					</div><!-- #masterinfo -->
 				</div><!-- /col -->
 			</div><!-- /row -->
-		</div><!-- /container-fluid -->
-	</footer><!-- #footer -->
-	<script src="assets/jquery-1.11.1.min.js" type="text/javascript"></script>
-	<script src="assets/DataTables-1.10.0/js/jquery.dataTables.min.js" type="text/javascript" charset="utf8"></script>
-	<script src="assets/bootstrap-3.1.1/js/bootstrap.min.js" type="text/javascript"></script>
-	<script src="assets/jquery.dataTables.rowGrouping-1.2.9.js" type="text/javascript"></script>
-	<script type="text/javascript">server_style = "hosted";</script>
-	<script src="assets/poudriere.js" type="text/javascript"></script>
-</body>
+			<div class="row">
+				<div class="col-md-12">
+					<div id="builds_div" class="status" style="display: none;">
+						<h2 id="builds">Builds
+							<a href="#"><span class="top-icon glyphicon glyphicon-chevron-up"></span></a>
+						</h2>
+						<table class="display builds table-bordered" id="builds_table">
+							<thead>
+								<tr>
+									<th>Build</th>
+									<th class="queued" title="Queued" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Queued</span><span class="hidden-md hidden-lg">Q</span></th>
+									<th class="built" title="Built" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Built</span><span class="hidden-md hidden-lg">B</span></th>
+									<th class="failed" title="Failed" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Failed</span><span class="hidden-md hidden-lg">F</span></th>
+									<th class="skipped" title="Skipped" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Skipped</span><span class="hidden-md hidden-lg">S</span></th>
+									<th class="ignored" title="Ignored" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Ignored</span><span class="hidden-md hidden-lg">I</span></th>
+									<th class="remaining" title="Remaining" data-toggle="tooltip" data-container="body"><span class="visible-md visible-lg">Remaining</span><span class="hidden-md hidden-lg">R</span></th>
+									<th>Status</th>
+									<th>Elapsed</th>
+								</tr>
+							</thead>
+							<tbody id="builds_body"></tbody>
+						</table>
+					</div><!-- #builds -->
+					<br class="clear" />
+				</div><!-- /col -->
+			</div><!-- /row -->
+		</div><!-- #main -->
+		<br class="clear" />
+		<footer class="navbar-fixed-bottom">
+			<div class="container-fluid">
+				<div class="row">
+					<div class="col-md-12">
+						<a class="pull-right" target="_new" href="http://fossil.etoilebsd.net/poudriere"><span class="glyphicon glyphicon-share-alt"></span>Poudriere</a>
+					</div><!-- /col -->
+				</div><!-- /row -->
+			</div><!-- /container-fluid -->
+		</footer><!-- #footer -->
+		<script src="assets/jquery-1.11.1.min.js" type="text/javascript"></script>
+		<script src="assets/DataTables-1.10.0/js/jquery.dataTables.min.js" type="text/javascript" charset="utf8"></script>
+		<script src="assets/bootstrap-3.1.1/js/bootstrap.min.js" type="text/javascript"></script>
+		<script src="assets/jquery.dataTables.rowGrouping-1.2.9.js" type="text/javascript"></script>
+		<script type="text/javascript">server_style = "hosted";</script>
+		<script src="assets/poudriere.js" type="text/javascript"></script>
+	</body>
 </html>
 <!-- vim: set sts=4 sw=4 ts=4 noet: -->


### PR DESCRIPTION
When the poudriere files are served as xhtml (with the mime type application/xhtml+xml) some errors would occur. These are fixed with these 2 patches. Tested in Safari & Firefox on a mac.
