### PR TITLE
Ignore /var/db/freebsd-update/ too.

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -1046,6 +1046,7 @@ markfs() {
 ./etc/shells
 ./etc/spwd.db
 ./tmp/*
+./var/db/freebsd-update/*
 ./var/db/pkg/*
 ./var/log/*
 ./var/mail/*


### PR DESCRIPTION
After a few upgrades, it can end up containing north of a hundred
thousand files, which will slow mtree a lot.