### PR TITLE
Add -K

### DIFF
--- a/src/share/poudriere/testport.sh
+++ b/src/share/poudriere/testport.sh
@@ -44,6 +44,7 @@ Options:
                    run a different number of jobs in parallel while preparing
                    the build. (Defaults to the number of CPUs)
     -k          -- Don't consider failures as fatal; find all failures.
+    -K          -- Kill jail if running.
     -N          -- Do not build package repository or INDEX when build
                    of dependencies completed
     -p tree     -- Specify the path to the portstree
@@ -68,10 +69,11 @@ SETNAME=""
 SKIPSANITY=0
 SKIP_RECURSIVE_REBUILD=0
 INTERACTIVE_MODE=0
+KILL_JAIL=no
 PTNAME="default"
 BUILD_REPO=1
 
-while getopts "o:cniIj:J:kNp:PsSvwz:" FLAG; do
+while getopts "o:cniIj:J:kKNp:PsSvwz:" FLAG; do
 	case "${FLAG}" in
 		c)
 			CONFIGSTR=1
@@ -92,6 +94,9 @@ while getopts "o:cniIj:J:kNp:PsSvwz:" FLAG; do
 			;;
 		k)
 			PORTTESTING_FATAL=no
+			;;
+		K)
+			KILL_JAIL=yes
 			;;
 		i)
 			INTERACTIVE_MODE=1
@@ -154,6 +159,7 @@ export MASTERNAME
 export MASTERMNT
 export POUDRIERE_BUILD_TYPE=bulk
 
+[ "$KILL_JAIL" = "yes" ] && jail_stop
 jail_start ${JAILNAME} ${PTNAME} ${SETNAME}
 
 if [ $CONFIGSTR -eq 1 ]; then


### PR DESCRIPTION
kills the jail specified in -j jail_name if its running
by calling jail_stop()