### PR TITLE
Make it possible to use jail -c -a arch -m src=/usr/src when arch is …

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -405,6 +405,9 @@ build_and_install_world() {
 install_from_src() {
 	local cpignore_flag cpignore
 
+	export TARGET=${ARCH%.*}
+	export TARGET_ARCH=${ARCH#*.}
+
 	msg_n "Copying ${SRC_BASE} to ${JAILMNT}/usr/src..."
 	mkdir -p ${JAILMNT}/usr/src
 	if [ -f ${SRC_BASE}/usr/src/.cpignore ]; then


### PR DESCRIPTION
…not equal to host uname -m and world has been cross-compiled using /usr/src sources and TARGET set to arch.

This fix should allow for example on a amd64 host:

poudriere jail -c -a i386 -v stable/10 -m src=/usr/src -j jailname
