### PR TITLE
Move XDEV check into installworld()  so that -m src will do the right…

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -4216,8 +4216,9 @@ prepare_ports() {
 		[ ${JAIL_NEEDS_CLEAN} -eq 1 ] &&
 		    msg_n "Cleaning all packages due to newer version of the jail..."
 
-		[ ${CLEAN} -eq 1 ] &&
+		if [ ${CLEAN} -eq 1 ] && [ ${JAIL_NEEDS_CLEAN} -ne 1 ]; then
 		    msg_n "(-c) Cleaning all packages..."
+		fi
 
 		if [ ${JAIL_NEEDS_CLEAN} -eq 1 ] || [ ${CLEAN} -eq 1 ]; then
 			rm -rf ${PACKAGES}/* ${cache_dir}


### PR DESCRIPTION
… thing when -x is passed.

This also respects SRC_DIR now so that -m src= actually works with -x instead of grabbing /usr/src versions of native-xtools.