### PR TITLE
Run test target on testport and bulk -t

### DIFF
--- a/src/bin/poudriere.8
+++ b/src/bin/poudriere.8
@@ -27,7 +27,7 @@
 .\"
 .\" Note: The date here should be updated whenever a non-trivial
 .\" change is made to the manual page.
-.Dd November 9, 2015
+.Dd March 30, 2016
 .Dt POUDRIERE 8
 .Os
 .Sh NAME
@@ -499,6 +499,9 @@ Show more verbose output.
 .Ss testport
 .Pp
 The specified port will be tested for build and packaging problems.
+This includes running its test target.
+Some ports might require you to also set the TEST option
+to provide a meaningful test target.
 All missing dependencies will first be built in parallel.
 .Ev TRYBROKEN=yes
 is automatically defined in the environment to test ports marked as

--- a/src/share/poudriere/bulk.sh
+++ b/src/share/poudriere/bulk.sh
@@ -48,8 +48,8 @@ Options:
     -n          -- Dry-run. Show what will be done, but do not build
                    any packages.
     -R          -- Clean RESTRICTED packages after building
-    -t          -- Test the specified ports for leftovers. Add -r to
-                   recursively test all dependencies as well.
+    -t          -- Run test target and test the specified ports for leftovers.
+                   Add -r to recursively test all dependencies as well.
     -r          -- Resursively test all dependencies as well
     -k          -- When doing testing with -t, don't consider failures as
                    fatal; don't skip dependent ports on findings.

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2204,7 +2204,9 @@ _real_build_port() {
 	fi
 	targets="check-sanity pkg-depends fetch-depends fetch checksum \
 		  extract-depends extract patch-depends patch build-depends \
-		  lib-depends configure build ${install_order} \
+		  lib-depends configure build \
+		  ${PORTTESTING:+test} \
+		  ${install_order} \
 		  ${PORTTESTING:+deinstall}"
 
 	# If not testing, then avoid rechecking deps in build/install;
@@ -2257,6 +2259,9 @@ _real_build_port() {
 					testfailure=2
 				fi
 			fi
+			;;
+		test)
+			max_execution_time=3600
 			;;
 		checksum|*-depends|install-mtree) JUSER=root ;;
 		stage) [ -n "${PORTTESTING}" ] && markfs prestage ${mnt} ;;
@@ -2345,7 +2350,11 @@ _real_build_port() {
 					bset_job_status "${phase}/timeout" "${port}"
 					job_msg_verbose "Status for build ${COLOR_PORT}${port}${COLOR_RESET}: ${COLOR_PHASE}timeout"
 				fi
-				return 1
+				if [ "${phase}" != "test" -o "${PORTTESTING_FATAL}" != "no" ]; then
+					return 1
+				else
+					testfailure=2
+				fi
 			fi
 		fi
 


### PR DESCRIPTION
This is an attempt to address #291

It might make more sense to provide this as a separate
command line option though.

It would also be good to have a way to automatically set
option TEST (should be optional though, as you want
to be able to test ports without this option set)

Also, max execution time is a bit arbitrary.