### PR TITLE
Switch BUILD_AS_NON_ROOT as default to on.

### DIFF
--- a/src/etc/poudriere.conf.sample
+++ b/src/etc/poudriere.conf.sample
@@ -221,8 +221,8 @@ DISTFILES_CACHE=/usr/ports/distfiles
 #PRESERVE_TIMESTAMP=yes
 
 # Define to yes to build and stage as a regular user
-# Default: no
-#BUILD_AS_NON_ROOT=yes
+# Default: yes
+#BUILD_AS_NON_ROOT=no
 
 # Define pkgname globs to boost priority for
 # Default: none

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -4762,7 +4762,7 @@ fi
 : ${PIDFILE:=${POUDRIERE_DATA}/daemon.pid}
 : ${QUEUE_SOCKET:=/var/run/poudriered.sock}
 : ${PORTBUILD_USER:=nobody}
-: ${BUILD_AS_NON_ROOT:=no}
+: ${BUILD_AS_NON_ROOT:=yes}
 : ${DISTFILES_CACHE:=/nonexistent}
 : ${SVN_CMD:=$(which svn 2>/dev/null || which svnlite 2>/dev/null)}
 # 24 hours for 1 command


### PR DESCRIPTION
It's been long enough, there should be no ports that don't build as root, and I'm tired of going over them every month and fixing them...