### PR TITLE
Fix BASEFS over NFS if the NFS server's TZ differed from the local TZ

### DIFF
--- a/src/share/poudriere/include/parallel.sh
+++ b/src/share/poudriere/include/parallel.sh
@@ -250,6 +250,9 @@ nohang() {
 
 	fifo=$(mktemp -ut nohang.pipe)
 	mkfifo ${fifo}
+	# If the fifo is over NFS, newly created fifos have the server's
+	# mtime not the client's mtime until the client writes to it
+	touch ${fifo}
 	exec 8<> ${fifo}
 	rm -f ${fifo}
 


### PR DESCRIPTION
If BASEFS is on an NFS mount, nohang was immediately killing builds
if the NFS server's timezone differed from the local timezone. This
appears to be because fifos created over NFS initially have their
mtime set to the server's local time not the clients. Working around
this by adding a "touch" after creating the nohang fifo.