### PR TITLE
image: Firmware mode improvement

### DIFF
--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -126,6 +126,11 @@ post_getopts
 : ${IMAGENAME:=poudriereimage}
 MASTERNAME=${JAILNAME}-${PTNAME}${SETNAME:+-${SETNAME}}
 
+# CFG_SIZE set /etc and /var ramdisk size and /cfg partition size
+# DATA_SIZE set /data partition size
+CFG_SIZE="32m"
+DATA_SIZE="32m"
+
 # Limitation on isos
 case "${IMAGENAME}" in
 ''|*[!A-Za-z0-9]*)
@@ -155,14 +160,19 @@ excludelist=$(mktemp -t excludelist)
 mkdir -p ${WRKDIR}/world
 mkdir -p ${WRKDIR}/out
 [ -z "${EXCLUDELIST}" ] || cat ${EXCLUDELIST} > ${excludelist}
+# Some poudriere jail directory used for upgrading source or binary based jail
+# are useless on the final image
 cat >> ${excludelist} << EOF
 usr/src
+var/db/freebsd-update
+var/db/etcupdate
+boot/kernel.old
 EOF
 case "${MEDIATYPE}" in
 usb|*firmware|rawdisk)
 	truncate -s ${IMAGESIZE} ${WRKDIR}/raw.img
 	md=$(/sbin/mdconfig ${WRKDIR}/raw.img)
-	newfs -j -L ${IMAGENAME} /dev/${md}
+	newfs -L ${IMAGENAME} /dev/${md}
 	mount /dev/${md} ${WRKDIR}/world
 	;;
 zrawdisk)
@@ -262,11 +272,51 @@ usb|rawdisk)
 	EOF
 	;;
 *firmware)
+	# Configuring nanobsd-like mode
+	# It re-use diskless(8) framework but using a /cfg configuration partition
+	# It needs a "config save" script too, like the nanobsd example:
+	#  /usr/src/tools/tools/nanobsd/Files/root/save_cfg
+	# Or the BSDRP config script:
+	#  https://github.com/ocochard/BSDRP/blob/master/BSDRP/Files/usr/local/sbin/config
+	# Because rootfs is readonly, it create ramdisks for /etc and /var
+	# Then we need to replace /tmp by a symlink to /var/tmp
+	# For more information, read /etc/rc.initdiskless
 	cat >> ${WRKDIR}/world/etc/fstab <<-EOF
-	/dev/gpt/${IMAGENAME}0 / ufs ro 1 1
+	/dev/gpt/${IMAGENAME}1 / ufs ro 1 1
+	/dev/gpt/cfg /cfg ufs rw,noatime,noauto 2 2
+	/dev/gpt/data /data ufs rw,noauto,failok 2 2
 	EOF
-	mkdir -p ${WRKDIR}/world/conf/base
-	tar -C ${WRKDIR}/world -X ${excludelist} -cf - etc | tar -xf - -C ${WRKDIR}/world/conf/base
+	# Enable diskless(8) mode
+	touch ${WRKDIR}/world/etc/diskless
+	for d in cfg data; do
+		mkdir -p ${WRKDIR}/world/$d
+	done
+	# Declare system name into /etc/nanobsd.conf: Allow to re-use nanobsd script
+	echo "NANO_DRIVE=gpt/${IMAGENAME}" > ${WRKDIR}/world/etc/nanobsd.conf
+	# Move /usr/local/etc to /etc/local (Only /etc will be backuped)
+    if [ -d ${WRKDIR}/world/usr/local/etc ] ; then
+        mkdir -p ${WRKDIR}/world/etc/local
+		tar -C ${WRKDIR}/world -X ${excludelist} -cf - usr/local/etc/ | tar -xf - -C ${WRKDIR}/world/etc/local
+        rm -rf ${WRKDIR}/world/usr/local/etc
+        ln -s /etc/local ${WRKDIR}/world/usr/local/etc
+    fi
+
+	# Copy /etc and /var to /conf/base as "reference"
+	for d in var etc; do
+		mkdir -p ${WRKDIR}/world/conf/base/$d ${WRKDIR}/world/conf/default/$d
+		tar -C ${WRKDIR}/world -X ${excludelist} -cf - $d | tar -xf - -C ${WRKDIR}/world/conf/base
+	done
+	# Set ram disks size
+	echo "$CFG_SIZE" > ${WRKDIR}/world/conf/base/etc/md_size
+	echo "$CFG_SIZE" > ${WRKDIR}/world/conf/base/var/md_size
+    echo "mount -o ro /dev/gpt/cfg" > ${WRKDIR}/world/conf/default/etc/remount
+	# replace /tmp by a symlink to /var/tmp
+	rm -rf ${WRKDIR}/world/tmp
+	ln -s /var/tmp ${WRKDIR}/world/tmp
+	# For correct booting it needs ufs formatted /cfg and /data partitions
+	TMPFILE=`mktemp -t poudriere-firmware` || exit 1
+	makefs -B little -s ${CFG_SIZE} ${WRKDIR}/cfg.img ${TMPFILE}
+	makefs -B little -s ${DATA_SIZE} ${WRKDIR}/data.img ${TMPFILE}
 	;;
 zrawdisk)
 	cat >> ${WRKDIR}/world/boot/loader.conf <<-EOF
@@ -315,10 +365,10 @@ firmware)
 	mkimg -s gpt -b ${mnt}/boot/pmbr \
 		-p efi:=${mnt}/boot/boot1.efifat \
 		-p freebsd-boot:=${mnt}/boot/gptboot \
-		-p freebsd-ufs/${IMAGENAME}0:=${WRKDIR}/raw.img \
-		-p freebsd-ufs/${IMAGENAME}1::${IMAGESIZE} \
-		-p freebsd-ufs/cfg::32M \
-		-p freebsd-ufs/data::200M \
+		-p freebsd-ufs/${IMAGENAME}1:=${WRKDIR}/raw.img \
+		-p freebsd-ufs/${IMAGENAME}2::${IMAGESIZE} \
+		-p freebsd-ufs/cfg:=${WRKDIR}/cfg.img \
+		-p freebsd-ufs/data:=${WRKDIR}/data.img \
 		-o ${OUTPUTDIR}/${FINALIMAGE}
 	;;
 rawfirmware)


### PR DESCRIPTION
- Add nanobsd diskless(8) mode.
  firmware use read-only root filesystem, then it needs to use ram disk for /etc (and /usr/local/etc) and /var
  nanobsd use a very specific diskless(8) mode for allowing to copy /etc (and /usr/local/etc) into the specific cfg partition
  This backup script can be the nanobsd one (/usr/src/tools/tools/nanobsd/Files/root/save_cfg) or others nanobsd based project script
- Replace root filesystem gpt label from 3-4 to 1-2 (like nanobsd)
- Exclude some big useless directories to be installed on the image like var/db/freebsd-update, var/db/etcupdate and boot/kernel.old
  This folder are left after poudriere jail update and useless in a firmware case
- Remove the SUJ (then the big .journal file) because as read-only filesystem, it's usage is useless too

There is still one bug to fix, but I don't find the root cause:
On a poudriere-firmware image running, permission of /etc (a ramdisk created by /etc/rc.initdiskless) are wrong.
Replacing usage of tar by cpio didn't fix the problem, I need to check if replacing usage of makefs/mkimg by old mdconfig fix this strange permission problem.
