### PR TITLE
Add support for file:/// URLs with git

### DIFF
--- a/src/share/poudriere/ports.sh
+++ b/src/share/poudriere/ports.sh
@@ -151,6 +151,7 @@ if [ -n "${SOURCES_URL}" ]; then
 		ssh://*) METHOD="git+ssh" ;;
 		https://*) METHOD="git+https" ;;
 		git://*) METHOD="git" ;;
+		file:///*) METHOD="git" ;;
 		*) err 1 "Invalid git url" ;;
 		esac
 		;;


### PR DESCRIPTION
Adding this line allows poudriere to grab the ports tree from a repo on a local filesystem.
