### PR TITLE
Honoring the -p option in option directory name in the options command

### DIFF
--- a/doc/poudriere.8.wiki
+++ b/doc/poudriere.8.wiki
@@ -762,6 +762,10 @@ It is very easy to extend it so that we can easily add other tests if wanted.</d
 </blockquote>
 <blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
 <div class="display">
+<code class="lit">/usr/local/etc/poudriere.d/&lt;tree&gt;-&lt;setname&gt;-options</code></div>
+</blockquote>
+<blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
+<div class="display">
 <code class="lit">/usr/local/etc/poudriere.d/&lt;setname&gt;-options</code></div>
 </blockquote>
 <blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
@@ -810,6 +814,10 @@ As a starter, you may want to copy an existing /var/db/ports/ to /usr/local/etc/
 </blockquote>
 <blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
 <div class="display">
+<code class="lit">/usr/local/etc/poudriere.d/&lt;tree&gt;-&lt;setname&gt;-blacklist</code></div>
+</blockquote>
+<blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
+<div class="display">
 <code class="lit">/usr/local/etc/poudriere.d/&lt;jailname&gt;-&lt;tree&gt;-blacklist</code></div>
 </blockquote>
 <blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
@@ -841,6 +849,10 @@ As a starter, you may want to copy an existing /var/db/ports/ to /usr/local/etc/
 </blockquote>
 <blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
 <div class="display">
+<code class="lit">/usr/local/etc/poudriere.d/&lt;tree&gt;-&lt;setname&gt;-poudriere.conf</code></div>
+</blockquote>
+<blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
+<div class="display">
 <code class="lit">/usr/local/etc/poudriere.d/&lt;jailname&gt;-&lt;tree&gt;-poudriere.conf</code></div>
 </blockquote>
 <blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
@@ -869,6 +881,10 @@ As a starter, you may want to copy an existing /var/db/ports/ to /usr/local/etc/
 <blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
 <div class="display">
 <code class="lit">/usr/local/etc/poudriere.d/&lt;jailname&gt;-make.conf</code></div>
+</blockquote>
+<blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
+<div class="display">
+<code class="lit">/usr/local/etc/poudriere.d/&lt;tree&gt;-&lt;setname&gt;-make.conf</code></div>
 </blockquote>
 <blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
 <div class="display">

--- a/doc/poudriere.8.wiki
+++ b/doc/poudriere.8.wiki
@@ -762,10 +762,6 @@ It is very easy to extend it so that we can easily add other tests if wanted.</d
 </blockquote>
 <blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
 <div class="display">
-<code class="lit">/usr/local/etc/poudriere.d/&lt;tree&gt;-&lt;setname&gt;-options</code></div>
-</blockquote>
-<blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
-<div class="display">
 <code class="lit">/usr/local/etc/poudriere.d/&lt;setname&gt;-options</code></div>
 </blockquote>
 <blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
@@ -814,10 +810,6 @@ As a starter, you may want to copy an existing /var/db/ports/ to /usr/local/etc/
 </blockquote>
 <blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
 <div class="display">
-<code class="lit">/usr/local/etc/poudriere.d/&lt;tree&gt;-&lt;setname&gt;-blacklist</code></div>
-</blockquote>
-<blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
-<div class="display">
 <code class="lit">/usr/local/etc/poudriere.d/&lt;jailname&gt;-&lt;tree&gt;-blacklist</code></div>
 </blockquote>
 <blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
@@ -849,10 +841,6 @@ As a starter, you may want to copy an existing /var/db/ports/ to /usr/local/etc/
 </blockquote>
 <blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
 <div class="display">
-<code class="lit">/usr/local/etc/poudriere.d/&lt;tree&gt;-&lt;setname&gt;-poudriere.conf</code></div>
-</blockquote>
-<blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
-<div class="display">
 <code class="lit">/usr/local/etc/poudriere.d/&lt;jailname&gt;-&lt;tree&gt;-poudriere.conf</code></div>
 </blockquote>
 <blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
@@ -881,10 +869,6 @@ As a starter, you may want to copy an existing /var/db/ports/ to /usr/local/etc/
 <blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
 <div class="display">
 <code class="lit">/usr/local/etc/poudriere.d/&lt;jailname&gt;-make.conf</code></div>
-</blockquote>
-<blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
-<div class="display">
-<code class="lit">/usr/local/etc/poudriere.d/&lt;tree&gt;-&lt;setname&gt;-make.conf</code></div>
 </blockquote>
 <blockquote style="margin-top: 0.00em;margin-bottom: 0.00em;">
 <div class="display">

--- a/src/bin/poudriere.8
+++ b/src/bin/poudriere.8
@@ -892,6 +892,7 @@ will check for any of these directories in this order:
 .Dl /usr/local/etc/poudriere.d/<jailname>-<tree>-<setname>-options
 .Dl /usr/local/etc/poudriere.d/<jailname>-<setname>-options
 .Dl /usr/local/etc/poudriere.d/<jailname>-<tree>-options
+.Dl /usr/local/etc/poudriere.d/<tree>-<setname>-options
 .Dl /usr/local/etc/poudriere.d/<setname>-options
 .Dl /usr/local/etc/poudriere.d/<tree>-options
 .Dl /usr/local/etc/poudriere.d/<jailname>-options
@@ -922,6 +923,7 @@ Any of the following are allowed and will all be used in the order shown:
 .Dl /usr/local/etc/poudriere.d/<setname>-blacklist
 .Dl /usr/local/etc/poudriere.d/<tree>-blacklist
 .Dl /usr/local/etc/poudriere.d/<jailname>-blacklist
+.Dl /usr/local/etc/poudriere.d/<tree>-<setname>-blacklist
 .Dl /usr/local/etc/poudriere.d/<jailname>-<tree>-blacklist
 .Dl /usr/local/etc/poudriere.d/<jailname>-<setname>-blacklist
 .Dl /usr/local/etc/poudriere.d/<jailname>-<tree>-<setname>-blacklist
@@ -937,6 +939,7 @@ Any of the following are allowed and will all be used in the order shown:
 .Dl /usr/local/etc/poudriere.d/<setname>-poudriere.conf
 .Dl /usr/local/etc/poudriere.d/<tree>-poudriere.conf
 .Dl /usr/local/etc/poudriere.d/<jailname>-poudriere.conf
+.Dl /usr/local/etc/poudriere.d/<tree>-<setname>-poudriere.conf
 .Dl /usr/local/etc/poudriere.d/<jailname>-<tree>-poudriere.conf
 .Dl /usr/local/etc/poudriere.d/<jailname>-<setname>-poudriere.conf
 .Dl /usr/local/etc/poudriere.d/<jailname>-<tree>-<setname>-poudriere.conf
@@ -949,6 +952,7 @@ Any of the following are allowed and will all be used in the order shown:
 .Dl /usr/local/etc/poudriere.d/<setname>-make.conf
 .Dl /usr/local/etc/poudriere.d/<tree>-make.conf
 .Dl /usr/local/etc/poudriere.d/<jailname>-make.conf
+.Dl /usr/local/etc/poudriere.d/<tree>-<setname>-make.conf
 .Dl /usr/local/etc/poudriere.d/<jailname>-<tree>-make.conf
 .Dl /usr/local/etc/poudriere.d/<jailname>-<setname>-make.conf
 .Dl /usr/local/etc/poudriere.d/<jailname>-<tree>-<setname>-make.conf

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -1890,8 +1890,12 @@ setup_makeconf() {
 	local makeconf opt
 	local arch host_arch
 
-	_jget arch "${name}" arch
 	get_host_arch host_arch
+	if [ -z "${name}" ]; then
+		arch="${host_arch}"
+	else
+		_jget arch "${name}" arch
+	fi
 
 	if need_cross_build "${host_arch}" "${arch}"; then
 		cat >> "${dst_makeconf}" <<-EOF

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -1374,7 +1374,9 @@ do_portbuild_mounts() {
 		    mnt_tmpfs config "${mnt}/var/db/ports"
 		optionsdir="${MASTERNAME}"
 		[ -n "${setname}" ] && optionsdir="${optionsdir} ${jname}-${setname}"
-		optionsdir="${optionsdir} ${jname}-${ptname} ${setname} ${ptname} ${jname} -"
+		optionsdir="${optionsdir} ${jname}-${ptname}"
+		[ -n "${setname}" ] && optionsdir="${optionsdir} ${ptname}-${setname} ${setname}"
+		optionsdir="${optionsdir} ${ptname} ${jname} -"
 
 		for opt in ${optionsdir}; do
 			use_options ${mnt} ${opt} && break || continue
@@ -1855,8 +1857,10 @@ load_blacklist() {
 	local setname=$3
 	local bl b bfile
 
-	bl="- ${setname} ${ptname} ${name} ${name}-${ptname}"
-	[ -n "${setname}" ] && bl="${bl} ${bl}-${setname} \
+	bl="- ${setname} ${ptname} ${name}"
+	[ -n "${setname}" ] && bl="${bl} ${ptname}-${setname}"
+	bl="${bl} ${name}-${ptname}"
+	[ -n "${setname}" ] && bl="${bl} ${name}-${setname} \
 		${name}-${ptname}-${setname}"
 	# If emulating always load a qemu-blacklist as it has special needs.
 	[ ${QEMU_EMULATING} -eq 1 ] && bl="${bl} qemu"
@@ -1897,7 +1901,9 @@ setup_makeconf() {
 		EOF
 	fi
 
-	makeconf="- ${setname} ${ptname} ${name} ${name}-${ptname}"
+	makeconf="- ${setname} ${ptname} ${name}"
+	[ -n "${setname}" ] && makeconf="${makeconf} ${ptname}-${setname}"
+	makeconf="${makeconf} ${name}-${ptname}"
 	[ -n "${setname}" ] && makeconf="${makeconf} ${name}-${setname} \
 		    ${name}-${ptname}-${setname}"
 	for opt in ${makeconf}; do
@@ -1928,6 +1934,8 @@ include_poudriere_confs() {
 	done
 
 	files="${setname} ${ptname} ${jail}"
+	[ -n "${ptname}" -a -n "${setname}" ] && \
+	    files="${files} ${ptname}-${setname}"
 	[ -n "${jail}" -a -n "${ptname}" ] && \
 	    files="${files} ${jail}-${ptname}"
 	[ -n "${jail}" -a -n "${setname}" ] && \

--- a/src/share/poudriere/options.sh
+++ b/src/share/poudriere/options.sh
@@ -49,6 +49,7 @@ EOF
 
 PTNAME=default
 SETNAME=""
+PTNAME_TMP=""
 DO_RECURSE=y
 COMMAND=config-conditional
 RECURSE_COMMAND=config-recursive
@@ -80,6 +81,7 @@ while getopts "cCj:f:p:nrsz:" FLAG; do
 			porttree_exists ${OPTARG} ||
 			    err 2 "No such ports tree: ${OPTARG}"
 			PTNAME=${OPTARG}
+			PTNAME_TMP=${OPTARG}
 			;;
 		n)
 			DO_RECURSE=
@@ -120,7 +122,7 @@ else
 	LISTPORTS="$@"
 fi
 
-PORT_DBDIR=${POUDRIERED}/${JAILNAME}${JAILNAME:+-}${SETNAME}${SETNAME:+-}options
+PORT_DBDIR=${POUDRIERED}/${JAILNAME}${JAILNAME:+-}${PTNAME_TMP}${PTNAME_TMP:+-}${SETNAME}${SETNAME:+-}options
 
 mkdir -p ${PORT_DBDIR}
 


### PR DESCRIPTION
The directory storing ports options doesn't contain the ports tree name
provided in the command line. It will be added if and only if a port tree
is provided (even if it's default)
This error is already reported by bapt@ (bug #176 ); I slightly improved his solution, ignoring the portstree name in the directory name if no -p is provided, but honoring it if "-p default" is used.
