### PR TITLE
Fixing the relpath() function, not considering partial comon name

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -264,7 +264,7 @@ relpath() {
 	[ $# -eq 2 ] || eargs relpath dir1 dir2
 	local dir1=$(realpath -q "$1" || echo "${1}")
 	local dir2=$(realpath -q "$2" || echo "${2}")
-	local common
+	local common newother
 
 	if [ "${#dir1}" -ge "${#dir2}" ]; then
 		common="${dir1}"
@@ -274,7 +274,16 @@ relpath() {
 		other="${dir1}"
 	fi
 	# Trim away path components until they match
-	while [ "${other#${common}}" = "${other}" -a -n "${common}" ]; do
+	while true; do
+		if [ "${other#${common}}" != "${other}" ]; then
+			newother="${other#${common}}"
+			if [ "${newother#/}" != "${newother}" ]; then
+				break
+			fi
+		fi
+		if [ -z "${common}" ]; then
+			break;
+		fi
 		common="${common%/*}"
 	done
 	common="${common:-/}"


### PR DESCRIPTION
real repro case:
relpath /appdata/poudriere/data/.m/101x64-adm5-default/ref/var/db/ports /appdata/poudriere-etc/poudriere.d/101x64-adm5-options

The output is:
/appdata/poudriere /data/.m/101x64-adm5-default/ref/var/db/ports -etc/poudriere.d/101x64-adm5-options

The proposed patch tries to fix the bug considering a string starting with '/' as good enough