### PR TITLE
Allow stage-qa to fail if there are proxydep errors

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2411,7 +2411,7 @@ _real_build_port() {
 			local die=0
 
 			bset_job_status "stage-qa" "${port}"
-			if ! injail env DEVELOPER=1 ${PORT_FLAGS} \
+			if ! injail env PROXYDEPS_FATAL=1 DEVELOPER=1 ${PORT_FLAGS} \
 			    /usr/bin/make -C ${portdir} stage-qa; then
 				msg "Error: stage-qa failures detected"
 				[ "${PORTTESTING_FATAL}" != "no" ] &&


### PR DESCRIPTION
ports Mk/Scripts/qa.sh will not return 1 if there's proxy dependencies
unless PROXYDEPS_FATAL is set.