### PR TITLE
jail: Add -C (for clean) option in order to clean poudriere data when deleting a jail

### DIFF
--- a/src/bin/poudriere.8
+++ b/src/bin/poudriere.8
@@ -411,6 +411,21 @@ This specifies which SET to start/stop the jail with.
 Build the native-xbuild target and copy this into the jail.
 Used exclusively
 for cross building a ports set, typically via qemu-user tools.
+.It Fl C Ar data
+Clean poudriere
+.Ar data
+folders when deleting a jail. Only used for
+.Sy -d
+option.
+.Pp
+.Bl -tag -width "packagesXX"
+.Pa data
+options are the following:
+.It Sy all
+.It Sy cache
+.It Sy logs
+.It Sy packages
+.It Sy wkrdirs
 .El
 .Ss ports
 .Pp


### PR DESCRIPTION
This change against branch [release-3.1](/freebsd/poudriere/tree/release-3.1) add a new option -C only used for jail delete (-d) operation in order to clean the poudriere data of the jail when deleting it. If no option -C is used, act as previously.

Options clean -C support different values:
- all
- cache
- logs
- packages
- wkrdis

Usage:

$ poudriere jail -d -j ${jname} -C [all|cache|logs|packages|wrkdirs]