### PR TITLE
do not copy src directory if -S option is also given when src method is used

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -416,22 +416,24 @@ build_and_install_world() {
 install_from_src() {
 	local cpignore_flag cpignore
 
-	msg_n "Copying ${SRC_BASE} to ${JAILMNT}/usr/src..."
-	mkdir -p ${JAILMNT}/usr/src
-	if [ -f ${SRC_BASE}/usr/src/.cpignore ]; then
-		cpignore_flag="-x"
-	else
-		cpignore=$(mktemp -t cpignore)
-		cpignore_flag="-X ${cpignore}"
-		# Ignore some files
-		cat > ${cpignore} <<-EOF
-		.git
-		.svn
-		EOF
+	if [ -z "$SRCPATH" ] ; then
+		msg_n "Copying ${SRC_BASE} to ${JAILMNT}/usr/src..."
+		mkdir -p ${JAILMNT}/usr/src
+		if [ -f ${SRC_BASE}/usr/src/.cpignore ]; then
+			cpignore_flag="-x"
+		else
+			cpignore=$(mktemp -t cpignore)
+			cpignore_flag="-X ${cpignore}"
+			# Ignore some files
+			cat > ${cpignore} <<-EOF
+			.git
+			.svn
+			EOF
+		fi
+		cpdup -i0 ${cpignore_flag} ${SRC_BASE} ${JAILMNT}/usr/src
+		[ -n "${cpignore}" ] && rm -f ${cpignore}
+		echo " done"
 	fi
-	cpdup -i0 ${cpignore_flag} ${SRC_BASE} ${JAILMNT}/usr/src
-	[ -n "${cpignore}" ] && rm -f ${cpignore}
-	echo " done"
 
 	setup_build_env
 	if [ ${BUILD} -eq 0 ]; then


### PR DESCRIPTION
This is useful for a scenario where I want to create a jail from a pre-built source tree, but for the builds that will use the jail I want to provide a different source tree.