### PR TITLE
Introduce switch to select if HTML files are inline or hosted

### DIFF
--- a/src/etc/poudriere.conf.sample
+++ b/src/etc/poudriere.conf.sample
@@ -286,3 +286,8 @@ DISTFILES_CACHE=/usr/ports/distfiles
 # special configuration is used where it is a problem.
 # Default: none
 #LOCAL_MTREE_EXCLUDES="/usr/obj /var/tmp/ccache"
+
+# Set to hosted to use the /data directory instead of inline style HTML
+# Default: inline
+#HTML_TYPE="hosted"
+

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -5531,6 +5531,8 @@ fi
 : ${BUILDNAME_FORMAT:="%Y-%m-%d_%Hh%Mm%Ss"}
 : ${BUILDNAME:=$(date +${BUILDNAME_FORMAT})}
 
+: ${HTML_TYPE:=inline}
+
 if [ -n "${MAX_MEMORY}" ]; then
 	MAX_MEMORY_BYTES="$((${MAX_MEMORY} * 1024 * 1024 * 1024))"
 fi

--- a/src/share/poudriere/include/html.sh
+++ b/src/share/poudriere/include/html.sh
@@ -151,11 +151,13 @@ install_html_files() {
 	# aliased /data dir. This can easily be auto-detected via JS
 	# but due to FF file:// restrictions requires a hack which
 	# results in a 404 for every page load.
-	if grep -q 'server_style = "hosted"' \
-	    "${log_top}/.html/index.html"; then
-		sed -i '' -e \
-		's/server_style = "hosted"/server_style = "inline"/' \
-		${log_top}/.html/*.html
+	if [ "${HTML_TYPE}" = "inline" ]; then
+	    if grep -q 'server_style = "hosted"' \
+		"${log_top}/.html/index.html"; then
+		    sed -i '' -e \
+		    's/server_style = "hosted"/server_style = "inline"/' \
+		    ${log_top}/.html/*.html
+	    fi
 	fi
 
 	mkdir -p "${dest}"


### PR DESCRIPTION
It is sometimes quite annoying if the HTML files are sed'ed with "inline".

This switch allows the user to select in poduriere.conf if this should happen.