### PR TITLE
Do not deadlock with random PIDs.

### DIFF
--- a/src/libexec/poudriere/pwait/pwait.c
+++ b/src/libexec/poudriere/pwait/pwait.c
@@ -86,6 +86,7 @@ main(int argc, char *argv[])
 	long pid;
 	char *s, *end;
 	double timeout;
+	pid_t me;
 
 	tflag = verbose = 0;
 	memset(&itv, 0, sizeof(itv));
@@ -146,6 +147,9 @@ main(int argc, char *argv[])
 
 	if (argc == 0)
 		usage();
+
+	me = getpid();
+
 #ifdef SHELL
 	INTOFF;
 	trap_push(SIGINFO, &info_oact);
@@ -177,6 +181,10 @@ main(int argc, char *argv[])
 		pid = strtol(s, &end, 10);
 		if (pid < 0 || *end != '\0' || errno != 0) {
 			warnx("%s: bad process id", s);
+			continue;
+		}
+		if (pid == me) {
+			warnx("%s: ignoring own process id", s);
 			continue;
 		}
 		duplicate = 0;


### PR DESCRIPTION
Fix a race condition where pwait would hang if passed its own pid. This
could happen if kern.randompid is set and a the intended waitee pid gets
recycled before pwait got called.

Instead of deadlocking just exit immediately.

This mirrors the bug I filed with FreeBSD at https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=218598