### PR TITLE
jail: Add -D option to keep git history

### DIFF
--- a/src/bin/poudriere.8
+++ b/src/bin/poudriere.8
@@ -449,6 +449,9 @@ is due to a bug in the native-xtools build which does not allow it to be
 built from the jail's own source.
 Used exclusively
 for cross building a ports set, typically via qemu-user tools.
+.It Fl D
+When creating the jail from a git checkout, clone it with the full history
+instead of a --depth=1.
 .El
 .Ss ports
 .Pp

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -62,6 +62,7 @@ Options:
                        url=SOMEURL.
     -P patch      -- Specify a patch to apply to the source before building.
     -S srcpath    -- Specify a path to the source tree to be used.
+    -D            -- Do a full git clone without --depth (default: --depth=1)
     -t version    -- Version of FreeBSD to upgrade the jail to.
     -U url        -- Specify a url to fetch the sources (with method git and/or svn).
     -x            -- Build and setup native-xtools cross compile tools in jail when
@@ -472,7 +473,7 @@ install_from_vcs() {
 				err 1 "Patch files not supported with git, please use feature branches"
 			fi
 			msg_n "Checking out the sources from git..."
-			git clone --depth=1 -q -b ${VERSION} ${GIT_FULLURL} ${SRC_BASE} || err 1 " fail"
+			git clone ${GIT_DEPTH} -q -b ${VERSION} ${GIT_FULLURL} ${SRC_BASE} || err 1 " fail"
 			echo " done"
 			# No support for patches, using feature branches is recommanded"
 			;;
@@ -876,8 +877,9 @@ PTNAME=default
 SETNAME=""
 XDEV=0
 BUILD=0
+GIT_DETPH=--depth=1
 
-while getopts "biJ:j:v:a:z:m:nf:M:sdkK:lqcip:r:uU:t:z:P:S:x" FLAG; do
+while getopts "biJ:j:v:a:z:m:nf:M:sdkK:lqcip:r:uU:t:z:P:S:Dx" FLAG; do
 	case "${FLAG}" in
 		b)
 			BUILD=1
@@ -944,6 +946,9 @@ while getopts "biJ:j:v:a:z:m:nf:M:sdkK:lqcip:r:uU:t:z:P:S:x" FLAG; do
 		S)
 			[ -d ${OPTARG} ] || err 1 "No such directory ${OPTARG}"
 			SRCPATH=${OPTARG}
+			;;
+		D)
+			GIT_DEPTH=""
 			;;
 		q)
 			QUIET=1


### PR DESCRIPTION
While it's useful to clone without history by default, sometime you
need the full one. For example if you rely on git tags to generate an image.

Signed-off-by: Emmanuel Vadot <emmanuel.vadot@gandi.net>