### PR TITLE
image: Use mdconfig for rawdisk

### DIFF
--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -174,6 +174,12 @@ cat >> ${excludelist} << EOF
 usr/src
 EOF
 case "${MEDIATYPE}" in
+rawdisk)
+	truncate -s ${IMAGESIZE} ${WRKDIR}/raw.img
+	md=$(/sbin/mdconfig ${WRKDIR}/raw.img)
+	newfs -j -L ${IMAGENAME} /dev/${md}
+	mount /dev/${md} ${WRKDIR}/world
+	;;
 zrawdisk)
 	truncate -s ${IMAGESIZE} ${WRKDIR}/raw.img
 	md=$(/sbin/mdconfig ${WRKDIR}/raw.img)
@@ -265,7 +271,12 @@ case ${MEDIATYPE} in
 	vfs.root.mountfrom="ufs:/dev/ufs/${IMAGENAME}"
 	EOF
 	;;
-usb|rawdisk)
+rawdisk)
+	cat >> ${WRKDIR}/world/etc/fstab <<-EOF
+	/dev/ufs/${IMAGENAME} / ufs rw 1 1
+	EOF
+	;;
+usb)
 	cat >> ${WRKDIR}/world/etc/fstab <<-EOF
 	/dev/ufs/${IMAGENAME} / ufs rw 1 1
 	EOF
@@ -335,6 +346,9 @@ rawfirmware)
 	;;
 rawdisk)
 	FINALIMAGE=${IMAGENAME}.img
+	umount ${WRKDIR}/world
+	/sbin/mdconfig -d -u ${md#md}
+	md=
 	mv ${WRKDIR}/raw.img ${OUTPUTDIR}/${FINALIMAGE}
 	;;
 zrawdisk)


### PR DESCRIPTION
makefs usage was introduce in commit 0e6b30405bd650a1d9b85672e6dd9f36047f2349
While this works great for embedded images, makefs calculate the number of
inodes based on the number of files. This lead to a really small number and
cause a problem for the type 'rawdisk' as this is mostly used for creating
base disk for virtual machines.

Signed-off-by: Emmanuel Vadot <emmanuel.vadot@gandi.net>