### PR TITLE
Check VERSION before running 'update_jail' using FreeBSD dists.

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -812,10 +812,10 @@ create_jail() {
 
 	markfs clean ${JAILMNT}
 
-	# Always update when using FreeBSD dists
+	# Check VERSION before running 'update_jail' on FreeBSD dists.
 	case ${METHOD} in
 		ftp|http|ftp-archive)
-			update_jail
+			[ ${VERSION#*-RELEAS*} != ${VERSION} ] && update_jail
 			;;
 	esac
 


### PR DESCRIPTION
Do not try to run 'update_jail' on PRERELEASE, STABLE or CURRENT if created jail was built using FreeBSD dists.

Before running freebsd-update(8) on created jails, check if its version match condition; only RELEASE branch is blessed by freebsd-update(8).