### PR TITLE
Verify TORELEASE before performing jail upgrade.

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -823,7 +823,7 @@ create_jail() {
 
 	markfs clean ${JAILMNT}
 
-	# Check VERSION before running 'update_jail' on FreeBSD dists.
+	# Check VERSION before running 'update_jail' on jails created using FreeBSD dists.
 	case ${METHOD} in
 		ftp|http|ftp-archive)
 			[ ${VERSION#*-RELEAS*} != ${VERSION} ] && update_jail

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -198,6 +198,16 @@ update_jail() {
 	msg "Upgrading using ${METHOD}"
 	case ${METHOD} in
 	ftp|http|ftp-archive)
+		# Verify if TORELEASE is supported by freebsd-update(8), if it's present.
+		if [ ! -z ${TORELEASE} ]; then
+		  case ${TORELEASE} in
+		    *-ALPHA*|*-CURRENT|*-PRERELEASE)
+			msg_error "Only release branches are supported by freebsd-update(8)."
+			msg_error "Please try to upgrade to a BETA, RC, or RELEASE version.
+			exit 1 ;;
+		    *) ;;
+		  esac
+		fi
 		MASTERMNT=${JAILMNT}
 		MASTERNAME=${JAILNAME}-${PTNAME}${SETNAME:+-${SETNAME}}
 		[ -n "${RESOLV_CONF}" ] && cp -v "${RESOLV_CONF}" "${JAILMNT}/etc/"

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -201,7 +201,7 @@ update_jail() {
 		# In case we use FreeBSD dists and TORELEASE is present, check if it's a release branch.
 		if [ ! -z ${TORELEASE} ]; then
 		  case ${TORELEASE} in
-		    *-ALPHA*|*-CURRENT|*-PRERELEASE)
+		    *-ALPHA*|*-CURRENT|*-PRERELEASE|*-STABLE)
 			msg_error "Only release branches are supported by freebsd-update(8)."
 			msg_error "Please try to upgrade to a new BETA, RC or RELEASE version."
 			exit 1 ;;

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -198,12 +198,12 @@ update_jail() {
 	msg "Upgrading using ${METHOD}"
 	case ${METHOD} in
 	ftp|http|ftp-archive)
-		# Verify if TORELEASE is supported by freebsd-update(8), if it's present.
+		# In case we use FreeBSD dists and TORELEASE is present, check if it's a release branch.
 		if [ ! -z ${TORELEASE} ]; then
 		  case ${TORELEASE} in
 		    *-ALPHA*|*-CURRENT|*-PRERELEASE)
 			msg_error "Only release branches are supported by freebsd-update(8)."
-			msg_error "Please try to upgrade to a BETA, RC, or RELEASE version.
+			msg_error "Please try to upgrade to a new BETA, RC or RELEASE version."
 			exit 1 ;;
 		    *) ;;
 		  esac

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -199,12 +199,13 @@ update_jail() {
 	case ${METHOD} in
 	ftp|http|ftp-archive)
 		# In case we use FreeBSD dists and TORELEASE is present, check if it's a release branch.
-		if [ ! -z ${TORELEASE} ]; then
+		if [ -n "${TORELEASE}" ]; then
 		  case ${TORELEASE} in
 		    *-ALPHA*|*-CURRENT|*-PRERELEASE|*-STABLE)
-			msg_error "Only release branches are supported by freebsd-update(8)."
+			msg_error "Only release branches are supported by the ${METHOD} method."
 			msg_error "Please try to upgrade to a new BETA, RC or RELEASE version."
-			exit 1 ;;
+			exit 1
+			;;
 		    *) ;;
 		  esac
 		fi


### PR DESCRIPTION
In case we use FreeBSD dists to try performing an upgrade on a jail, TORELEASE must be specified; although it must be checked to ensure if we are able to use it with freebsd-update(8). Only release branches like "BETA", "RC", and "RELEASE" are supported.

Check it even before trying to mount the jail prevents accidents (mounting jail rootfs, an additional fs), and "exit 1" ensures no unnecessary calls and traffic to FreeBSD's update servers will be performed.

+ Added silly orthography and info update to a comment from a previous commit.