### PR TITLE
Resolve "symlink verification" confusion before applying base system updates.

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -213,15 +213,14 @@ update_jail() {
 		chmod +x ${JAILMNT}/usr/sbin/freebsd-update.fixed
 		if [ -z "${TORELEASE}" ]; then
 			# We're running inside the jail so basedir is /.
-			# If we start using -b this needs to match it.
+			# If we start using '-b' this needs to match it.
 			basedir=/
-			bdhash="$(echo "${basedir}" | sha256 -q)"
-			if injail env PAGER=/bin/cat \
-			    /usr/sbin/freebsd-update.fixed fetch && \
-			    [ -L "${JAILMNT}/${bdhash}-install" ]; then
-				injail env PAGER=/bin/cat \
-				    /usr/sbin/freebsd-update.fixed install
-			fi
+			bdhash=$(echo ${basedir} | sha256 -q)
+			injail env PAGER=/bin/cat /usr/sbin/freebsd-update.fixed fetch && \
+			  # New updates are identified by a symlink containing the basedir hash and -install as suffix.
+			  # If we really have new updates to install, then install them.
+			  [ -L "${JAILMNT}/var/db/freebsd-update/${bdhash}-install" ] && \
+			    injail env PAGER=/bin/cat /usr/sbin/freebsd-update.fixed install
 		else
 			# Install new kernel
 			injail env PAGER=/bin/cat \


### PR DESCRIPTION
Jail creation using 'ftp' method (and release branches like 11.0-RELEASE) should be deploying updated and patched jails. Missing path to verify fetched and ready-to-install patches was causing confusion when Poudriere tried to perform base system updates.

Based on commit 47ff5fcd9687cc5e4a9118da9ca16b56eeb24276 from #385:

```
# poudriere version
3.1.19-15-g47ff5fcd
# poudriere jail -c -j hue11 -v 11.0-RELEASE
    ...
# poudriere jail -l | grep hue
hue11         11.0-RELEASE-p1  amd64 ftp    2017-07-05 15:11:01 /zim/poudriere/jails/hue11
```

Based on (patched) commit f58d05ae9afcfe04d9be16092205792c73cbfc5f:

```
# poudriere version
3.1.19-41-gf58d05ae
# poudriere jail -c -j patched11 -v 11.0-RELEASE
    ...
# poudriere jail -l | grep patched
patched11     11.0-RELEASE-p10 amd64 ftp    2017-07-05 15:35:18 /zim/poudriere/jails/patched11
```