### PR TITLE
Expand xdev support and setup hardlinks at jail startup time.

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2089,6 +2089,65 @@ qemu_install() {
 	cp -f "${EMULATOR}" "${mnt}${EMULATOR}"
 }
 
+setup_xdev() {
+	[ $# -eq 2 ] || eargs setup_xdev mnt target
+	local mnt="$1"
+	local target="$2"
+	local HLINK_FILES file
+
+	[ -d "${mnt}/nxb-bin" ] || return 0
+
+	msg_n "Setting up native-xtools environment in jail..."
+	cat > "${mnt}/etc/make.nxb.conf" <<-EOF
+	CC=/nxb-bin/usr/bin/cc
+	CPP=/nxb-bin/usr/bin/cpp
+	CXX=/nxb-bin/usr/bin/c++
+	AS=/nxb-bin/usr/bin/as
+	NM=/nxb-bin/usr/bin/nm
+	LD=/nxb-bin/usr/bin/ld
+	OBJCOPY=/nxb-bin/usr/bin/objcopy
+	SIZE=/nxb-bin/usr/bin/size
+	STRIPBIN=/nxb-bin/usr/bin/strip
+	SED=/nxb-bin/usr/bin/sed
+	READELF=/nxb-bin/usr/bin/readelf
+	RANLIB=/nxb-bin/usr/bin/ranlib
+	YACC=/nxb-bin/usr/bin/yacc
+	MAKE=/nxb-bin/usr/bin/make
+	STRINGS=/nxb-bin/usr/bin/strings
+	AWK=/nxb-bin/usr/bin/awk
+	FLEX=/nxb-bin/usr/bin/flex
+	EOF
+
+	# hardlink these files to capture scripts and tools
+	# that explicitly call them instead of using paths.
+	HLINK_FILES="usr/bin/env usr/bin/gzip usr/bin/id usr/bin/limits \
+			usr/bin/make usr/bin/dirname usr/bin/diff \
+			usr/bin/makewhatis \
+			usr/bin/find usr/bin/gzcat usr/bin/awk \
+			usr/bin/touch usr/bin/sed usr/bin/patch \
+			usr/bin/install usr/bin/gunzip usr/bin/sort \
+			usr/bin/tar usr/bin/xargs usr/sbin/chown bin/cp \
+			bin/cat bin/chmod bin/echo bin/expr \
+			bin/hostname bin/ln bin/ls bin/mkdir bin/mv \
+			bin/realpath bin/rm bin/rmdir bin/sleep \
+			sbin/sha256 sbin/sha512 sbin/md5 sbin/sha1"
+
+	# Endian issues on mips/mips64 are not handling exec of 64bit shells
+	# from emulated environments correctly.  This works just fine on ARM
+	# because of the same issue, so allow it for now.
+	[ ${target} = "mips" ] || \
+	    HLINK_FILES="${HLINK_FILES} bin/sh bin/csh"
+
+	for file in ${HLINK_FILES}; do
+		if [ -f "${mnt}/nxb-bin/${file}" ]; then
+			rm -f "${mnt}/${file}"
+			ln "${mnt}/nxb-bin/${file}" "${mnt}/${file}"
+		fi
+	done
+
+	echo " done"
+}
+
 jail_start() {
 	[ $# -lt 2 ] && eargs jail_start name ptname setname
 	local name=$1
@@ -2236,6 +2295,8 @@ jail_start() {
 
 	# Handle special QEMU needs.
 	if [ ${QEMU_EMULATING} -eq 1 ]; then
+		setup_xdev "${tomnt}" "${arch%.*}"
+
 		# QEMU is really slow. Extend the time significantly.
 		msg "Raising MAX_EXECUTION_TIME and NOHANG_TIME for QEMU"
 		MAX_EXECUTION_TIME=864000

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -411,63 +411,67 @@ build_and_install_world() {
 	fi
 
 	installworld
+	setup_xdev
+}
 
-	if [ ${XDEV} -eq 1 ]; then
-		msg "Starting make native-xtools with ${PARALLEL_JOBS} jobs"
-		${MAKE_CMD} -C /usr/src native-xtools ${MAKE_JOBS} \
-		    ${MAKEWORLDARGS} || err 1 "Failed to 'make native-xtools'"
-		XDEV_TOOLS=$(TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH} \
-		    ${MAKE_CMD} -C /usr/src -f Makefile.inc1 -V NXBDESTDIR)
-		: ${XDEV_TOOLS:=/usr/obj/${TARGET}.${TARGET_ARCH}/nxb-bin}
-		rm -rf ${JAILMNT}/nxb-bin || err 1 "Failed to remove old native-xtools"
-		mv ${XDEV_TOOLS} ${JAILMNT} || err 1 "Failed to move native-xtools"
-		cat > ${JAILMNT}/etc/make.nxb.conf <<- EOF
-		CC=/nxb-bin/usr/bin/cc
-		CPP=/nxb-bin/usr/bin/cpp
-		CXX=/nxb-bin/usr/bin/c++
-		AS=/nxb-bin/usr/bin/as
-		NM=/nxb-bin/usr/bin/nm
-		LD=/nxb-bin/usr/bin/ld
-		OBJCOPY=/nxb-bin/usr/bin/objcopy
-		SIZE=/nxb-bin/usr/bin/size
-		STRIPBIN=/nxb-bin/usr/bin/strip
-		SED=/nxb-bin/usr/bin/sed
-		READELF=/nxb-bin/usr/bin/readelf
-		RANLIB=/nxb-bin/usr/bin/ranlib
-		YACC=/nxb-bin/usr/bin/yacc
-		MAKE=/nxb-bin/usr/bin/make
-		STRINGS=/nxb-bin/usr/bin/strings
-		AWK=/nxb-bin/usr/bin/awk
-		FLEX=/nxb-bin/usr/bin/flex
-		EOF
+setup_xdev() {
+	[ ${XDEV} -eq 1 ] || return 0
+	[ -n "${MAKE_CMD}" ] || err 1 "setup_xdev: setup_build_env not called"
 
-		# hardlink these files to capture scripts and tools
-		# that explicitly call them instead of using paths.
-		HLINK_FILES="usr/bin/env usr/bin/gzip usr/bin/id usr/bin/limits \
-				usr/bin/make usr/bin/dirname usr/bin/diff \
-				usr/bin/makewhatis \
-				usr/bin/find usr/bin/gzcat usr/bin/awk \
-				usr/bin/touch usr/bin/sed usr/bin/patch \
-				usr/bin/install usr/bin/gunzip usr/bin/sort \
-				usr/bin/tar usr/bin/xargs usr/sbin/chown bin/cp \
-				bin/cat bin/chmod bin/echo bin/expr \
-				bin/hostname bin/ln bin/ls bin/mkdir bin/mv \
-				bin/realpath bin/rm bin/rmdir bin/sleep \
-				sbin/sha256 sbin/sha512 sbin/md5 sbin/sha1"
+	msg "Starting make native-xtools with ${PARALLEL_JOBS} jobs"
+	${MAKE_CMD} -C /usr/src native-xtools ${MAKE_JOBS} \
+	    ${MAKEWORLDARGS} || err 1 "Failed to 'make native-xtools'"
+	XDEV_TOOLS=$(TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH} \
+	    ${MAKE_CMD} -C /usr/src -f Makefile.inc1 -V NXBDESTDIR)
+	: ${XDEV_TOOLS:=/usr/obj/${TARGET}.${TARGET_ARCH}/nxb-bin}
+	rm -rf ${JAILMNT}/nxb-bin || err 1 "Failed to remove old native-xtools"
+	mv ${XDEV_TOOLS} ${JAILMNT} || err 1 "Failed to move native-xtools"
+	cat > ${JAILMNT}/etc/make.nxb.conf <<- EOF
+	CC=/nxb-bin/usr/bin/cc
+	CPP=/nxb-bin/usr/bin/cpp
+	CXX=/nxb-bin/usr/bin/c++
+	AS=/nxb-bin/usr/bin/as
+	NM=/nxb-bin/usr/bin/nm
+	LD=/nxb-bin/usr/bin/ld
+	OBJCOPY=/nxb-bin/usr/bin/objcopy
+	SIZE=/nxb-bin/usr/bin/size
+	STRIPBIN=/nxb-bin/usr/bin/strip
+	SED=/nxb-bin/usr/bin/sed
+	READELF=/nxb-bin/usr/bin/readelf
+	RANLIB=/nxb-bin/usr/bin/ranlib
+	YACC=/nxb-bin/usr/bin/yacc
+	MAKE=/nxb-bin/usr/bin/make
+	STRINGS=/nxb-bin/usr/bin/strings
+	AWK=/nxb-bin/usr/bin/awk
+	FLEX=/nxb-bin/usr/bin/flex
+	EOF
 
-		# Endian issues on mips/mips64 are not handling exec of 64bit shells
-		# from emulated environments correctly.  This works just fine on ARM
-		# because of the same issue, so allow it for now.
-		[ ${TARGET} = "mips" ] || \
-		    HLINK_FILES="${HLINK_FILES} bin/sh bin/csh"
+	# hardlink these files to capture scripts and tools
+	# that explicitly call them instead of using paths.
+	HLINK_FILES="usr/bin/env usr/bin/gzip usr/bin/id usr/bin/limits \
+			usr/bin/make usr/bin/dirname usr/bin/diff \
+			usr/bin/makewhatis \
+			usr/bin/find usr/bin/gzcat usr/bin/awk \
+			usr/bin/touch usr/bin/sed usr/bin/patch \
+			usr/bin/install usr/bin/gunzip usr/bin/sort \
+			usr/bin/tar usr/bin/xargs usr/sbin/chown bin/cp \
+			bin/cat bin/chmod bin/echo bin/expr \
+			bin/hostname bin/ln bin/ls bin/mkdir bin/mv \
+			bin/realpath bin/rm bin/rmdir bin/sleep \
+			sbin/sha256 sbin/sha512 sbin/md5 sbin/sha1"
 
-		for file in ${HLINK_FILES}; do
-			if [ -f "${JAILMNT}/nxb-bin/${file}" ]; then
-				rm -f ${JAILMNT}/${file}
-				ln ${JAILMNT}/nxb-bin/${file} ${JAILMNT}/${file}
-			fi
-		done
-	fi
+	# Endian issues on mips/mips64 are not handling exec of 64bit shells
+	# from emulated environments correctly.  This works just fine on ARM
+	# because of the same issue, so allow it for now.
+	[ ${TARGET} = "mips" ] || \
+	    HLINK_FILES="${HLINK_FILES} bin/sh bin/csh"
+
+	for file in ${HLINK_FILES}; do
+		if [ -f "${JAILMNT}/nxb-bin/${file}" ]; then
+			rm -f ${JAILMNT}/${file}
+			ln ${JAILMNT}/nxb-bin/${file} ${JAILMNT}/${file}
+		fi
+	done
 }
 
 install_from_src() {

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -383,7 +383,7 @@ setup_src_conf() {
 	    ${JAILMNT}/etc/${src}.conf
 }
 
-build_and_install_world() {
+buildworld() {
 	export SRC_BASE=${JAILMNT}/usr/src
 	mkdir -p ${JAILMNT}/etc
 	setup_src_conf "src"
@@ -409,9 +409,6 @@ build_and_install_world() {
 			KERNCONF=${KERNEL} ${MAKEWORLDARGS} || \
 			err 1 "Failed to 'make buildkernel'"
 	fi
-
-	installworld
-	setup_xdev
 }
 
 setup_xdev() {
@@ -499,7 +496,9 @@ install_from_src() {
 		setup_build_env
 		installworld
 	else
-		build_and_install_world
+		buildworld
+		installworld
+		setup_xdev
 	fi
 	# Use __FreeBSD_version as our version_extra
 	setvar "${var_version_extra}" \
@@ -557,7 +556,9 @@ install_from_vcs() {
 			;;
 		esac
 	fi
-	build_and_install_world
+	buildworld
+	installworld
+	setup_xdev
 
 	case ${METHOD} in
 	svn*)

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -417,6 +417,7 @@ buildworld() {
 build_native_xtools() {
 	[ ${XDEV} -eq 1 ] || return 0
 	[ ${BUILT_NATIVE_XTOOLS:-0} -eq 0 ] || return 0
+	need_emulation "${ARCH}" || return 0
 	setup_build_env
 
 	msg "Starting make native-xtools with ${PARALLEL_JOBS} jobs"

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -276,6 +276,7 @@ update_jail() {
 		update_version
 		[ -n "${RESOLV_CONF}" ] && rm -f ${JAILMNT}/etc/resolv.conf
 		update_version_env $(jget ${JAILNAME} version)
+		setup_xdev
 		markfs clean ${JAILMNT}
 		;;
 	svn*|git*)
@@ -415,6 +416,7 @@ buildworld() {
 
 setup_xdev() {
 	[ ${XDEV} -eq 1 ] || return 0
+	[ ${SETUP_XDEV:-0} -eq 0 ] || return 0
 	setup_build_env
 
 	msg "Starting make native-xtools with ${PARALLEL_JOBS} jobs"
@@ -472,6 +474,8 @@ setup_xdev() {
 			ln ${JAILMNT}/nxb-bin/${file} ${JAILMNT}/${file}
 		fi
 	done
+
+	SETUP_XDEV=1
 }
 
 install_from_src() {
@@ -726,6 +730,8 @@ install_from_ftp() {
 	msg_n "Cleaning up..."
 	rm -rf ${JAILMNT}/fromftp/
 	echo " done"
+
+	setup_xdev
 }
 
 install_from_tar() {

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -418,7 +418,7 @@ setup_xdev() {
 	msg "Starting make native-xtools with ${PARALLEL_JOBS} jobs"
 	: ${XDEV_SRC:=/usr/src}
 	${MAKE_CMD} -C ${XDEV_SRC} native-xtools ${MAKE_JOBS} \
-	    ${MAKEWORLDARGS} || err 1 "Failed to 'make native-xtools'"
+	    ${MAKEWORLDARGS} || err 1 "Failed to 'make native-xtools' in ${XDEV_SRC}"
 	XDEV_TOOLS=$(TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH} \
 	    ${MAKE_CMD} -C ${XDEV_SRC} -f Makefile.inc1 -V NXBDESTDIR)
 	: ${XDEV_TOOLS:=/usr/obj/${TARGET}.${TARGET_ARCH}/nxb-bin}

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -339,6 +339,8 @@ installworld() {
 setup_build_env() {
 	local hostver
 
+	[ -n "${MAKE_CMD}" ] && return 0
+
 	JAIL_OSVERSION=$(awk '/^\#define[[:blank:]]__FreeBSD_version/ {print $3}' ${SRC_BASE}/sys/sys/param.h)
 	hostver=$(awk '/^\#define[[:blank:]]__FreeBSD_version/ {print $3}' /usr/include/sys/param.h)
 	MAKE_CMD=make
@@ -413,7 +415,7 @@ buildworld() {
 
 setup_xdev() {
 	[ ${XDEV} -eq 1 ] || return 0
-	[ -n "${MAKE_CMD}" ] || err 1 "setup_xdev: setup_build_env not called"
+	setup_build_env
 
 	msg "Starting make native-xtools with ${PARALLEL_JOBS} jobs"
 	: ${XDEV_SRC:=/usr/src}
@@ -730,6 +732,7 @@ install_from_tar() {
 	msg_n "Installing ${VERSION} ${ARCH} from ${TARBALL} ..."
 	tar -xpf ${TARBALL} -C ${JAILMNT}/ || err 1 " fail"
 	echo " done"
+	setup_xdev
 }
 
 create_jail() {

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -164,7 +164,7 @@ update_version_env() {
 	login_env=",UNAME_r=${release% *},UNAME_v=FreeBSD ${release},OSVERSION=${osversion}"
 
 	# Tell pkg(8) to not use /bin/sh for the ELF ABI since it is native.
-	need_emulation  "${ARCH}" && \
+	[ ${QEMU_EMULATING} -eq 1 ] && \
 	    login_env="${login_env},ABI_FILE=\/usr\/lib\/crt1.o"
 
 	# Check TARGET=i386 not TARGET_ARCH due to pc98/i386
@@ -417,7 +417,7 @@ buildworld() {
 build_native_xtools() {
 	[ ${XDEV} -eq 1 ] || return 0
 	[ ${BUILT_NATIVE_XTOOLS:-0} -eq 0 ] || return 0
-	need_emulation "${ARCH}" || return 0
+	[ ${QEMU_EMULATING} -eq 1 ] || return 0
 	setup_build_env
 
 	msg "Starting make native-xtools with ${PARALLEL_JOBS} jobs"

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -499,8 +499,8 @@ install_from_src() {
 	else
 		buildworld
 		installworld
-		setup_xdev
 	fi
+	setup_xdev
 	# Use __FreeBSD_version as our version_extra
 	setvar "${var_version_extra}" \
 	    "$(awk '/^\#define[[:blank:]]__FreeBSD_version/ {print $3}' \

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -416,10 +416,11 @@ setup_xdev() {
 	[ -n "${MAKE_CMD}" ] || err 1 "setup_xdev: setup_build_env not called"
 
 	msg "Starting make native-xtools with ${PARALLEL_JOBS} jobs"
-	${MAKE_CMD} -C /usr/src native-xtools ${MAKE_JOBS} \
+	: ${XDEV_SRC:=/usr/src}
+	${MAKE_CMD} -C ${XDEV_SRC} native-xtools ${MAKE_JOBS} \
 	    ${MAKEWORLDARGS} || err 1 "Failed to 'make native-xtools'"
 	XDEV_TOOLS=$(TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH} \
-	    ${MAKE_CMD} -C /usr/src -f Makefile.inc1 -V NXBDESTDIR)
+	    ${MAKE_CMD} -C ${XDEV_SRC} -f Makefile.inc1 -V NXBDESTDIR)
 	: ${XDEV_TOOLS:=/usr/obj/${TARGET}.${TARGET_ARCH}/nxb-bin}
 	rm -rf ${JAILMNT}/nxb-bin || err 1 "Failed to remove old native-xtools"
 	mv ${XDEV_TOOLS} ${JAILMNT} || err 1 "Failed to move native-xtools"


### PR DESCRIPTION
- Expand `jail -x` support to methods: _tar_, _src_ without `-b`, and _ftp_ type methods. Fixes #477 and obsoletes #478 
- Xdev hardlinks are now setup at jail start time rather than `jail -cu` time.  This allows less modifications to the jail's snapshot and not requiring rebuilding a jail if Poudriere decides to modify the _HLINK_FILES_ list.  Fixes #445 