### PR TITLE
Fix LOIP4/6 checks which always fail when using poudriere in a jail

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -6918,10 +6918,10 @@ fi
 if [ ${JAILED} -eq 1 ]; then
 	# !! Note these exit statuses are inverted
 	ifconfig | \
-	    awk -vip="${LOIP4}" '$1 == "inet6" && $2 == ip {exit 1}' && \
+	    awk -vip="${LOIP6}" '$1 == "inet6" && $2 == ip {exit 1}' && \
 	    LOIP6=
 	ifconfig | \
-	    awk -vip="${LOIP6}" '$1 == "inet" && $2 == ip {exit 1}' && \
+	    awk -vip="${LOIP4}" '$1 == "inet" && $2 == ip {exit 1}' && \
 	    LOIP4=
 fi
 case $IPS in


### PR DESCRIPTION
The check for if address from LOIP4 and LOIP6 are using the wrong addresses so they will always fail. Because of this no address is assigned to the local only jail and as a result building a lot of packages failed to build, including python and ruby.

This PR fixes the checks so it actually looks for an inet address with LOIP4 and an inet6 address with LOIP6, this was reversed earlier.