### PR TITLE
jail: Add -C (for clean) option in order to clean poudriere data when deleting a jailJail clean

### DIFF
--- a/src/bin/poudriere.8
+++ b/src/bin/poudriere.8
@@ -522,6 +522,22 @@ is due to a bug in the native-xtools build which does not allow it to be
 built from the jail's own source.
 Used exclusively
 for cross building a ports set, typically via qemu-user tools.
+.It Fl C Ar data
+Clean poudriere
+.Ar data
+folders when deleting a jail. Only used for
+.Sy -d
+option.
+.Pp
+.Bl -tag -width "packagesXX"
+.Pa data
+options are the following:
+.It Sy all
+.It Sy cache
+.It Sy logs
+.It Sy packages
+.It Sy wkrdirs
+.El
 .It Fl D
 When creating the jail from a git checkout, clone it with the full history
 instead of a --depth=1.

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -141,7 +141,7 @@ delete_jail() {
 	rm -rf ${POUDRIERED}/jails/${JAILNAME} ${cache_dir} \
 		${POUDRIERE_DATA}/.m/${JAILNAME}-* || :
 	echo " done"
-	if [ "${CLEANJAIL}" == "none" ]; then
+	if [ "${CLEANJAIL}" = "none" ]; then
 		return 0
 	fi
 	msg_n "Cleaning ${JAILNAME} data..."


### PR DESCRIPTION
This change against branch [master](/freebsd/poudriere/tree/master) add a new option -C only used for jail delete (-d) operation in order to clean the poudriere data of the jail when deleting it. If no option -C is used, act as previously.

Options clean -C support different values:
- all
- cache
- logs
- packages
- wkrdis

Usage:

$ poudriere jail -d -j ${jname} -C [all|cache|logs|packages|wrkdirs]