### PR TITLE
Poudriere is not able to stage some ports if "security.bsd.hardlink_check_*" != 0

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2227,7 +2227,9 @@ jail_start() {
 		err 1 "The ports name cannot contain a period (.). See jail(8)"
 	[ "${setname#*.*}" = "${setname}" ] ||
 		err 1 "The set name cannot contain a period (.). See jail(8)"
-
+	if [ ! $(sysctl -n security.bsd.hardlink_check_uid) -eq 0 -o ! $(sysctl -n security.bsd.hardlink_check_uid) -eq 0 ]; then
+		err 1 "Poudriere is not able to stage some ports if 'security.bsd.hardlink_check_uid' or 'security.bsd.hardlink_check_uid' are not set to '0'."
+	fi
 	if [ -z "${NOLINUX}" ]; then
 		if [ "${arch}" = "i386" -o "${arch}" = "amd64" ]; then
 			needfs="${needfs} linprocfs"

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2228,7 +2228,15 @@ jail_start() {
 	[ "${setname#*.*}" = "${setname}" ] ||
 		err 1 "The set name cannot contain a period (.). See jail(8)"
 	if [ ! $(sysctl -n security.bsd.hardlink_check_uid) -eq 0 -o ! $(sysctl -n security.bsd.hardlink_check_gid) -eq 0 ]; then
-		err 1 "Poudriere is not able to stage some ports if 'security.bsd.hardlink_check_uid' or 'security.bsd.hardlink_check_gid' are not set to '0'."
+		case ${BUILD_AS_NON_ROOT} in
+			[Yy][Ee][Ss])
+				msg_warn "You have BUILD_AS_NON_ROOT set to '${BUILD_AS_NON_ROOT}' (c.f. poudriere.conf),"
+				msg_warn "    and 'security.bsd.hardlink_check_uid' or 'security.bsd.hardlink_check_gid' are not set to '0'."
+				err 1 "Poudriere will not be able to stage some ports. Exiting."
+				;;
+			*)
+				;;
+		esac
 	fi
 	if [ -z "${NOLINUX}" ]; then
 		if [ "${arch}" = "i386" -o "${arch}" = "amd64" ]; then

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2228,7 +2228,7 @@ jail_start() {
 	[ "${setname#*.*}" = "${setname}" ] ||
 		err 1 "The set name cannot contain a period (.). See jail(8)"
 	if [ ! $(sysctl -n security.bsd.hardlink_check_uid) -eq 0 -o ! $(sysctl -n security.bsd.hardlink_check_gid) -eq 0 ]; then
-		err 1 "Poudriere is not able to stage some ports if 'security.bsd.hardlink_check_uid' or 'security.bsd.hardlink_check_uid' are not set to '0'."
+		err 1 "Poudriere is not able to stage some ports if 'security.bsd.hardlink_check_uid' or 'security.bsd.hardlink_check_gid' are not set to '0'."
 	fi
 	if [ -z "${NOLINUX}" ]; then
 		if [ "${arch}" = "i386" -o "${arch}" = "amd64" ]; then

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2227,7 +2227,7 @@ jail_start() {
 		err 1 "The ports name cannot contain a period (.). See jail(8)"
 	[ "${setname#*.*}" = "${setname}" ] ||
 		err 1 "The set name cannot contain a period (.). See jail(8)"
-	if [ ! $(sysctl -n security.bsd.hardlink_check_uid) -eq 0 -o ! $(sysctl -n security.bsd.hardlink_check_uid) -eq 0 ]; then
+	if [ ! $(sysctl -n security.bsd.hardlink_check_uid) -eq 0 -o ! $(sysctl -n security.bsd.hardlink_check_gid) -eq 0 ]; then
 		err 1 "Poudriere is not able to stage some ports if 'security.bsd.hardlink_check_uid' or 'security.bsd.hardlink_check_uid' are not set to '0'."
 	fi
 	if [ -z "${NOLINUX}" ]; then

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2227,7 +2227,7 @@ jail_start() {
 		err 1 "The ports name cannot contain a period (.). See jail(8)"
 	[ "${setname#*.*}" = "${setname}" ] ||
 		err 1 "The set name cannot contain a period (.). See jail(8)"
-	if [ ! $(sysctl -n security.bsd.hardlink_check_uid) -eq 0 -o ! $(sysctl -n security.bsd.hardlink_check_gid) -eq 0 ]; then
+	if [ -n "${HARDLINK_CHECK}" -a ! "${HARDLINK_CHECK}" = "00" ]; then
 		case ${BUILD_AS_NON_ROOT} in
 			[Yy][Ee][Ss])
 				msg_warn "You have BUILD_AS_NON_ROOT set to '${BUILD_AS_NON_ROOT}' (c.f. poudriere.conf),"

--- a/src/share/poudriere/include/common.sh.freebsd
+++ b/src/share/poudriere/include/common.sh.freebsd
@@ -28,3 +28,6 @@ if [ ${JAILED} -eq 0 ] || \
     [ $(sysctl -n security.jail.sysvipc_allowed) -eq 1 ]; then
 	JAIL_PARAMS="${JAIL_PARAMS:+${JAIL_PARAMS} }allow.sysvipc"
 fi
+
+# Hardlink Checks (NONE = 00, UID = 10, GID = 01, UID+GID = 11)
+HARDLINK_CHECK="$(sysctl -n security.bsd.hardlink_check_uid)$(sysctl -n security.bsd.hardlink_check_gid)"


### PR DESCRIPTION
Staging and packaging will fail if 'security.bsd.hardlink_check_uid' or 'security.bsd.hardlink_check_gid' are not set to '0'.

Hope that is the right place to put this kind of check.