### PR TITLE
processonelog: add case for common lld linker error

### DIFF
--- a/src/share/poudriere/processonelog.sh
+++ b/src/share/poudriere/processonelog.sh
@@ -36,6 +36,8 @@ elif bzgrep -qE "\.(c|cc|cxx|cpp|h|y)[0-9:]+ .+\.[hH](: No such file|' file not 
   reason="missing_header"
 elif bzgrep -qE '(nested function.*declared but never defined|warning: nested extern declaration)' $1; then
   reason="nested_declaration"
+elif bzgrep -qE 'error: .* create dynamic relocation .* against symbol: .* in readonly segment' $1; then
+  reason="lld_linker_error"
 # note: must be run before compiler_error
 elif bzgrep -q '#warning "this file includes <sys/termios.h>' $1; then
   reason="termios"


### PR DESCRIPTION
Needs to be before 'termios'.  Example error, from p5-Math-Pari:

/usr/bin/ld: error: can't create dynamic relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol: gpmalloc in readonly segment
>>> defined in init.o
>>> referenced by mp.c
>>>               mp.o:(pari_kernel_init)