### PR TITLE
(WIP) Package seeding

### DIFF
--- a/src/etc/poudriere.conf.sample
+++ b/src/etc/poudriere.conf.sample
@@ -309,3 +309,9 @@ DISTFILES_CACHE=/usr/ports/distfiles
 # processing of the queue slightly, especially for bulk -a bulds.
 # Default: no
 #HTML_TRACK_REMAINING=yes
+
+# Do package seeding or not (fetching required binary packages from a mirror
+# that has the exact version we want)
+# Default: no
+#PKG_SEEDING=yes
+#PKG_SEEDING_MIRROR=pkg.freebsd.org

--- a/src/share/poudriere/bulk.sh
+++ b/src/share/poudriere/bulk.sh
@@ -55,6 +55,7 @@ Options:
                    fatal; don't skip dependent ports on findings.
     -T          -- Try to build broken ports anyway
     -F          -- Only fetch from original master_site (skip FreeBSD mirrors)
+    -s          -- Do package seeding
     -S          -- Don't recursively rebuild packages affected by other
                    packages requiring incremental rebuild. This can result
                    in broken packages if the ones updated do not retain
@@ -91,7 +92,7 @@ INTERACTIVE_MODE=0
 
 [ $# -eq 0 ] && usage
 
-while getopts "B:iIf:j:J:CcknNp:RFtrTSvwz:a" FLAG; do
+while getopts "B:iIf:j:J:CcknNp:RFtrTsSvwz:a" FLAG; do
 	case "${FLAG}" in
 		B)
 			BUILDNAME="${OPTARG}"
@@ -157,6 +158,9 @@ while getopts "B:iIf:j:J:CcknNp:RFtrTSvwz:a" FLAG; do
 			;;
 		R)
 			NO_RESTRICTED=1
+			;;
+		s)
+			PKG_SEEDING=1
 			;;
 		S)
 			SKIP_RECURSIVE_REBUILD=1

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2704,7 +2704,7 @@ jail_cleanup() {
 	export CLEANED_UP=1
 }
 
-# return 0 if the package dir exists and has packages, 0 otherwise
+# return 0 if the package dir exists and has packages, 1 otherwise
 package_dir_exists_and_has_packages() {
 	[ ! -d ${PACKAGES}/All ] && return 1
 	dirempty ${PACKAGES}/All && return 1
@@ -5468,7 +5468,7 @@ gather_port_vars() {
 
 	clear_dep_fatal_error
 	parallel_start
-	for originspec in $(listed_ports show_moved); do
+	for originspec in $(listed_ports); do
 		originspec_decode "${originspec}" origin dep_args flavor
 		[ ${ALL} -eq 0 ] && [ -n "${flavor}" ] && \
 		    ! have_ports_feature FLAVORS && \


### PR DESCRIPTION
Right after the first `clean_build_queue` call:

1. For all packages in `${MASTERMNT}/.p/all_pkgs`, if it's not marked "listed" or if it's not in
    `${PACKAGES}/All`, try fetch its `${pkg}-${ver}.txz` from pkg.freebsd.org.
    If it succeeds, place the .txz into `${PACKAGES}/All`.
2. Call `clean_build_queue` to remove fetched packages from build queue.

It is still not clear to me whether to place fetched packages in `${PACKAGES}/All` or in `${MASTERMNT}/packages/All`.  It seems that because `${MASTERMNT}/packages/All` is in jail, it is read-only, but that is where `clean_build_queue` checks.  Need help on this part.

Note: the code is still WIP and not working properly ...
Fix #319