### PR TITLE
testport should accept "-B"

### DIFF
--- a/src/share/poudriere/testport.sh
+++ b/src/share/poudriere/testport.sh
@@ -73,7 +73,7 @@ INTERACTIVE_MODE=0
 PTNAME="default"
 BUILD_REPO=1
 
-while getopts "o:cniIj:J:kNp:PSvwz:" FLAG; do
+while getopts "B:o:cniIj:J:kNp:PSvwz:" FLAG; do
 	case "${FLAG}" in
 		B)
 			BUILDNAME="${OPTARG}"


### PR DESCRIPTION
testport doesn't accept "-B" option because it doesn't list in getopts list.
This patch inserts it with a ":" character.