### PR TITLE
made ports tree creation fail for portsnap when a branch was specified.

### DIFF
--- a/src/share/poudriere/ports.sh
+++ b/src/share/poudriere/ports.sh
@@ -274,6 +274,11 @@ if [ ${CREATE} -eq 1 ]; then
 	if [ $FAKE -eq 0 ]; then
 		case ${METHOD} in
 		portsnap)
+
+			if [ -n "$BRANCH" ]; then
+				err 1 "portsnap does not support branches, use '-m svn' (or another method supporting branches) or drop '-B $BRANCH'."
+			fi
+
 			# additional portsnap arguments
 			PTARGS=$(check_portsnap_interactive)
 			mkdir ${PTMNT}/.snap


### PR DESCRIPTION
This PR would fix issue #586, but it
- assumes that portsnap is the only (-m) method not supporting branches, which I haven't verified
- is a bit suboptimal because the check is only run after zfs dataset creation