### PR TITLE
Fix default permissions to cfg and data partitions

### DIFF
--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -449,9 +449,12 @@ usb)
 	fi
 
 	# For correct booting it needs ufs formatted /cfg and /data partitions
-	TMPFILE=`mktemp -t poudriere-firmware` || exit 1
-	makefs -B little -s ${CFG_SIZE} ${WRKDIR}/cfg.img ${TMPFILE}
-	makefs -B little -s ${DATA_SIZE} ${WRKDIR}/data.img ${TMPFILE}
+	TMPDIR=`mktemp -d -t poudriere-firmware` || exit 1
+	# Set proper permissions to this empty directory: /cfg (so /etc) and /data once mounted will inherit them
+	chmod -R 755 ${TMPDIR}
+	makefs -B little -s ${CFG_SIZE} ${WRKDIR}/cfg.img ${TMPDIR}
+	makefs -B little -s ${DATA_SIZE} ${WRKDIR}/data.img ${TMPDIR}
+	rm -rf ${TMPDIR}
 	makefs -B little -s ${OS_SIZE}m -o label=${IMAGENAME} \
 		-o version=2 ${WRKDIR}/raw.img ${WRKDIR}/world
 	;;


### PR DESCRIPTION
Need to use empty directory with proper permission for creating empty partition with makefs: This fixes the too restricted /etc ramdisk too.

Previously, soon after booting, error messages appear:

```
Feb 12 18:11:00 router cron[732]: _secure_path: cannot stat /etc/login.conf: Permission denied
Feb 12 18:22:00 router cron[744]: _secure_path: cannot stat /etc/login.conf: Permission denied
Feb 12 18:33:00 router cron[755]: _secure_path: cannot stat /etc/login.conf: Permission denied
Feb 12 18:44:00 router cron[767]: _secure_path: cannot stat /etc/login.conf: Permission denied
```

Permission of /etc are not correct:

```
root@router:~ #  ll / | grep etc
d---------  29 root  wheel  2560 Feb 12 17:50 etc/
```
The source of theses problem were that permission to cfg and data partitons created by makefs was wrong.

Notice there is another bug somewhere I need to fix regarding the diskless mode: During boot process, files from /cfg are correctly copied into /etc, but seems ignored by RC scripts later.