### PR TITLE
prevent to populate /etc/rc.conf.d/ by default

### DIFF
--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -311,9 +311,10 @@ touch ${WRKDIR}/src.conf
 make -C ${mnt}/usr/src DESTDIR=${WRKDIR}/world BATCH_DELETE_OLD_FILES=yes SRCCONF=${WRKDIR}/src.conf delete-old delete-old-libs
 
 # Set hostname
+# diskless mode didn't support to remove default files into /etc/, but only to add or modify existing filess
+# So providing file into /etc/rc.conf.d/ should be avoided 
 if [ -n "${HOSTNAME}" ]; then
-	mkdir -p ${WRKDIR}/world/etc/rc.conf.d
-	echo "hostname=${HOSTNAME}" > ${WRKDIR}/world/etc/rc.conf.d/hostname
+	echo "hostname=${HOSTNAME}" > ${WRKDIR}/world/etc/rc.conf
 fi
 
 [ ! -d "${EXTRADIR}" ] || cp -fRLp ${EXTRADIR}/ ${WRKDIR}/world/


### PR DESCRIPTION
Populating /etc/rc.conf.d/ with default image is not compliant with diskless mode.
Detailed explanation with the default /etc/rc.conf.d/hostname in firmware (diskless) mode:

1. System boot, detect diskless mode, then create ramdisk /etc, copy /conf/base/etc into /etc, then /cfg over /etc (empty for the first boot), then start all RC scripts
2. User choose to create an /etc/rc.conf with a new hostname then reboot
3. System boot, detect diskless mode, then create ramdisk /etc, copy /conf/base/etc into /etc, then /cfg (then the new rc.conf) over /etc, then start all RC scripts
=> system boot, but with still the previous set-by-default hostname (because default "hostname" file is still in /etc/rc.conf.d/hostname.
And diskless didn't allow to delete files into /etc (only new or different from existing /conf/base/etc) are backuped into /cfg.
Because /etc/rc.conf.d/ has more priority than /etc/rc.conf, the default behavior should be to set the default hostname into /etc/rc.conf than into /etc/rc.conf.d/hostname.