### PR TITLE
Resetting load attempts counter

### DIFF
--- a/src/share/poudriere/html/assets/poudriere.js
+++ b/src/share/poudriere/html/assets/poudriere.js
@@ -71,6 +71,7 @@ function update_data() {
 			'Cache-Control': 'max-age=0',
 		},
 		success: function(data) {
+			load_attempts = 0;
 			process_data(data);
 		},
 		error: function(data) {


### PR DESCRIPTION
The load attempts counter must be reset after successful loading of data.json otherwise code will react to total number of errors, not sequential one