### PR TITLE
Shush make by default in jail command

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -390,7 +390,7 @@ setup_build_env() {
 
 	JAIL_OSVERSION=$(awk '/^\#define[[:blank:]]__FreeBSD_version/ {print $3}' ${SRC_BASE}/sys/sys/param.h)
 	hostver=$(awk '/^\#define[[:blank:]]__FreeBSD_version/ {print $3}' /usr/include/sys/param.h)
-	MAKE_CMD=make
+	MAKE_CMD="make -s"
 	if [ ${hostver} -gt 1000000 -a ${JAIL_OSVERSION} -lt 1000000 ]; then
 		FMAKE=$(command -v fmake 2>/dev/null)
 		[ -n "${FMAKE}" ] ||


### PR DESCRIPTION
poudriere can generate a lot of output, so try and keep it quieter in normal case