### PR TITLE
Add option to allow ZFS dataset access and extra parameters for builder jails

### DIFF
--- a/src/etc/poudriere.conf.sample
+++ b/src/etc/poudriere.conf.sample
@@ -1,7 +1,6 @@
-
 # Poudriere can optionally use ZFS for its ports/jail storage. For
 # ZFS define ZPOOL, otherwise set NO_ZFS=yes
-# 
+#
 #### ZFS
 # The pool where poudriere will create all the filesystems it needs
 # poudriere will use ${ZPOOL}/${ZROOTFS} as its root
@@ -311,3 +310,25 @@ DISTFILES_CACHE=/usr/ports/distfiles
 # processing of the queue slightly, especially for bulk -a builds.
 # Default: no
 #HTML_TRACK_REMAINING=yes
+
+# Devices available in builder jails via devfs
+# See also JAIL_ZFS_JAILED_DATASETS.
+# Default: null zero random urandom stdin stdout stderr fd fd/* bpf* pts pts/*
+#JAIL_DEVFS_PATH="null zero random urandom stdin stdout stderr fd fd/* bpf* pts pts/* usb"
+
+# Extra configuration parameters for builder jails, see jail(8).
+# Default: none
+# Example that may be helpful together with JAIL_ZFS_JAILED_DATASETS to
+# allow builder jails access to specified ZFS datasets:
+#JAIL_EXTRA_PARAMS="allow.mount allow.mount.zfs enforce_statfs=1"
+
+# ZFS datasets made available in builder jails. See `zfs jail` command
+# in zfs(8). These datasets need the property `jailed=on`.
+# Using this feature implicitly adds `zfs` to JAIL_DEVFS_PATH i.e.
+# unhides /dev/zfs inside the jails as required to access ZFS datasets from
+# inside builder jails. See also the example in JAIL_EXTRA_PARAMS for how to
+# allow access to the datasets within the jails (not changed implicitly
+# because you may want other values for `enforce_statfs`).
+# This is unrelated to the NO_ZFS option!
+# Default: none
+#JAIL_ZFS_JAILED_DATASETS="zroot/poudriere/buildartifacts"


### PR DESCRIPTION
This is the preparation for a use case I'm developing with @grembo and @xgarcias at our company PPRO. Namely, we want to package whole application jails (FreeBSD base + package dependencies + application) into a package for use in a new deployment mechanism. The presentation is proposed as talk "Joker: safe and automated deployments using FreeBSD jails" for EuroBSDcon 2018, and we would like to get the necessary patch ready so people could try the solution right after the talk instead of having to wait for a poudriere release. *I believe this patch is generally useful*, but also we are very sure to use this feature for our purposes (not a hobby project).

I can provide a sample port Makefile showing how it's used, but the basic idea is simple: instead of building a *software* port, we package a filesystem snapshot: `zfs create parentdataset/myappjail`, install FreeBSD release and packages in it, then ~ `zfs snapshot parentdataset/myappjail@export && zfs send parentdataset/myappjail@export | xz -c >zfs-image.txz`. We end up with a package containing that compressed ZFS dataset image which we can use in the port's post-install script to extract and make the jail ready once the package gets installed. The deployment mechanism then leverages safe switching between old and new jail whenever an application deployment needs to happen. If you want more info on this use case, let me know.

Or in summary: allow port builds to fiddle with a restricted list of ZFS datasets

-----------

Tested with 3.2.6, and then applied the patch cleanly to master branch.