### PR TITLE
Create user/group only if required

### DIFF
--- a/src/etc/poudriere.conf.sample
+++ b/src/etc/poudriere.conf.sample
@@ -264,14 +264,16 @@ DISTFILES_CACHE=/usr/ports/distfiles
 # to that user.  Then set CCACHE_DIR_NON_ROOT_SAFE to yes.
 #BUILD_AS_NON_ROOT=no
 
-# Define to the username to build as when BUILD_AS_NON_ROOT is yes.
+# Define to the username and groupname to build as when BUILD_AS_NON_ROOT is yes.
 # Default: nobody (uid PORTBUILD_UID)
 #PORTBUILD_USER=nobody
+#PORTBUILD_GROUP=nobody
 
-# Define to the uid to use for PORTBUILD_USER if the user does not
+# Define to the uid and gid to use for PORTBUILD_USER if the user does not
 # already exist in the jail.
 # Default: 65532
 #PORTBUILD_UID=65534
+#PORTBUILD_GID=65534
 
 # Define pkgname globs to boost priority for
 # Default: none

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2514,13 +2514,15 @@ jail_start() {
 	fi
 	injail id >/dev/null 2>&1 || \
 	    err 1 "Unable to execute id(1) in jail. Emulation or ABI wrong."
-	portbuild_uid=$(injail id -u ${PORTBUILD_USER} 2>/dev/null || :)
+	portbuild_uid=$(injail id -u "${PORTBUILD_USER}" 2>/dev/null || :)
 	if [ -z "${portbuild_uid}" ]; then
 		msg_n "Creating user/group ${PORTBUILD_USER}"
-		injail pw groupadd ${PORTBUILD_USER} -g ${PORTBUILD_UID} || \
-		err 1 "Unable to create group ${PORTBUILD_USER}"
-		injail pw useradd ${PORTBUILD_USER} -u ${PORTBUILD_UID} -d /nonexistent -c "Package builder" || \
-		err 1 "Unable to create user ${PORTBUILD_USER}"
+		injail pw groupshow "${PORTBUILD_USER}" >/dev/null 2>&1 || \
+		injail pw groupadd "${PORTBUILD_USER}" -g "${PORTBUILD_UID}" || \
+		    err 1 "Unable to create group ${PORTBUILD_USER}"
+		injail pw useradd "${PORTBUILD_USER}" -u "${PORTBUILD_UID}" \
+		    -g "${PORTBUILD_USER}" -d /nonexistent -c "Package builder" || \
+		    err 1 "Unable to create user ${PORTBUILD_USER}"
 		echo " done"
 	else
 		PORTBUILD_UID=${portbuild_uid}


### PR DESCRIPTION
Add the option to specify the group name used, and only create the user/group if required.

This prevents a failure if the group already exists when we try to create the user, and allows finer grained control over the user name, group name, uid, and gid.