### PR TITLE
Document that hook plugins can provide make.conf, but not with filename patterns

### DIFF
--- a/src/bin/poudriere.8
+++ b/src/bin/poudriere.8
@@ -27,7 +27,7 @@
 .\"
 .\" Note: The date here should be updated whenever a non-trivial
 .\" change is made to the manual page.
-.Dd March 8, 2018
+.Dd June 19, 2018
 .Dt POUDRIERE 8
 .Os
 .Sh NAME
@@ -400,9 +400,7 @@ Any of the following are allowed and will all be used in the order shown:
 .Dl Pa /usr/local/etc/poudriere.d/<jailname>-<tree>-make.conf
 .Dl Pa /usr/local/etc/poudriere.d/<jailname>-<setname>-make.conf
 .Dl Pa /usr/local/etc/poudriere.d/<jailname>-<tree>-<setname>-make.conf
-The
-.Pa /usr/local/etc/poudriere.d/hooks/plugins/<plugin>/
-directory may contain any of the above patterns as well.
+.Dl Pa /usr/local/etc/poudriere.d/hooks/plugins/<plugin>/make.conf
 .Ss Create optional src.conf
 You can also specify a global src.conf which will be used for building
 jails with the


### PR DESCRIPTION
Follow-up to #618.

Relevant code as proof:

```
makeconf="- ${setname} ${ptname} ${name}"
[ -n "${setname}" ] && makeconf="${makeconf} ${ptname}-${setname}"
makeconf="${makeconf} ${name}-${ptname}"
[ -n "${setname}" ] && makeconf="${makeconf} ${name}-${setname} \
        ${name}-${ptname}-${setname}"
for opt in ${makeconf}; do
    append_make "${POUDRIERED}" "${opt}" "${dst_makeconf}"
done

# Check for and load plugin make.conf files
if [ -d "${HOOKDIR}/plugins" ]; then
    for plugin_dir in ${HOOKDIR}/plugins/*; do
        # Check empty dir
        case "${plugin_dir}" in
        "${HOOKDIR}/plugins/*") break ;;
        esac
        append_make "${plugin_dir}" "-" "${dst_makeconf}" # <----------
    done
fi
```