### PR TITLE
Replace broken portsmon with freshports

### DIFF
--- a/src/share/poudriere/html/assets/poudriere.js
+++ b/src/share/poudriere/html/assets/poudriere.js
@@ -102,7 +102,7 @@ function format_origin(origin, flavor) {
 	}
 
 	return "<a target=\"_new\" title=\"freshports for " + origin +
-		"\" href=\"https://freshports.org/" +
+		"\" href=\"https://www.freshports.org/" +
 		data[0] + "/" + data[1] + "/\"><span " +
 		"class=\"glyphicon glyphicon-tasks\"></span>"+ origin + flavor +
 		"</a>";

--- a/src/share/poudriere/html/assets/poudriere.js
+++ b/src/share/poudriere/html/assets/poudriere.js
@@ -101,9 +101,9 @@ function format_origin(origin, flavor) {
 		flavor = '';
 	}
 
-	return "<a target=\"_new\" title=\"portsmon for " + origin +
-		"\" href=\"http://portsmon.freebsd.org/portoverview.py?category=" +
-		data[0] + "&amp;portname=" + data[1] + "\"><span " +
+	return "<a target=\"_new\" title=\"freshports for " + origin +
+		"\" href=\"http://freshports.org/" +
+		data[0] + "/" + data[1] + "\"><span " +
 		"class=\"glyphicon glyphicon-tasks\"></span>"+ origin + flavor +
 		"</a>";
 }

--- a/src/share/poudriere/html/assets/poudriere.js
+++ b/src/share/poudriere/html/assets/poudriere.js
@@ -102,8 +102,8 @@ function format_origin(origin, flavor) {
 	}
 
 	return "<a target=\"_new\" title=\"freshports for " + origin +
-		"\" href=\"http://freshports.org/" +
-		data[0] + "/" + data[1] + "\"><span " +
+		"\" href=\"https://freshports.org/" +
+		data[0] + "/" + data[1] + "/\"><span " +
 		"class=\"glyphicon glyphicon-tasks\"></span>"+ origin + flavor +
 		"</a>";
 }


### PR DESCRIPTION
Portsmon has been broken since October 2017. So I think it makes sense to change the links to point at freshports.