### PR TITLE
Create a dataset for poudriere/data/images during initial setup

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -1365,6 +1365,7 @@ get_data_dir() {
 			${ZPOOL}${ZROOTFS}/data
 		zfs create ${ZPOOL}${ZROOTFS}/data/.m
 		zfs create -o compression=off ${ZPOOL}${ZROOTFS}/data/cache
+		zfs create -o compression=on ${ZPOOL}${ZROOTFS}/data/images
 		zfs create -o compression=lz4 ${ZPOOL}${ZROOTFS}/data/logs
 		zfs create -o compression=off ${ZPOOL}${ZROOTFS}/data/packages
 		zfs create -o compression=off ${ZPOOL}${ZROOTFS}/data/wrkdirs


### PR DESCRIPTION
When the `poudriere image` sub command was created, a dataset was not created for its output.

Since these are large files, it is advantageous to have a dataset. Since these files can be sparse, it makes sense to enable compression.

Rather than specify a specific type of compression, use the default (currently LZ4 but may change to something better some day in the future).