### PR TITLE
On failure, don't leave md(4) devices laying around

### DIFF
--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -54,6 +54,7 @@ EOF
 delete_image() {
 	[ ! -f "${excludelist}" ] || rm -f ${excludelist}
 	[ -z "${zroot}" ] || zpool destroy -f ${zroot}
+	[ -z "${md}" ] || /sbin/mdconfig -d -u ${md#md}
 
 	destroyfs ${WRKDIR} image
 }


### PR DESCRIPTION
During cleanup, also cleanup any mdconfig devices that were created