### PR TITLE
image: adds zsnapshot imagetype

### DIFF
--- a/src/bin/poudriere-image.8
+++ b/src/bin/poudriere-image.8
@@ -54,6 +54,8 @@ This specifies a list of packages to be pre-installed in the final image.
 This specifies the hostname used for the image.
 Defaults to
 .Ar poudriere-image .
+.It Fl i Ar originimage
+Path to a previously built full.img.gz.
 .It Fl j Ar name
 This argument specifies the name of the jail that is used.
 .It Fl m Ar overlaydir
@@ -67,6 +69,8 @@ This argument specifies directory where the resulting image will be created.
 This argument specifies the name of the ports tree that is used.
 .It Fl s Ar size
 This specifies the maximum size of the image that is built.
+.It Fl S Ar snapshotname
+Name of the snapshot for zsnapshot type.
 .It Fl t Ar type
 This specifies the type of image to create:
 .Bl -tag -width "rawfirmware"
@@ -97,6 +101,8 @@ A nanobsd style image with a GPT partitions and a UEFI boot loader.
 A raw disk image.
 .It embedded
 Create a u-boot ready embedded image.
+.It zsnapshot
+Create a zfs snapshot full and incremental to be used in a jail.
 .El
 .It Fl X Ar excludefile
 This specifies a list of files to exclude from the final image.


### PR DESCRIPTION
The purpose of this format is to be able to run jails off a zfs snapshot
a couple of files would be generated:
  - NAME-VERSION.manifest.json
  - NAME-VERSION.full.img.gz
  - NAME-latest.manifest.json -> NAME-VERSION.manifest.json (symlink)
and optionaly (if image is generated off a previous snapshot):
  - NAME-VERSION.incr.img.gz
  - NAME-VERSION.modified.files

The full image is the result of zfs send ran off the image builder,
the incremental zfs image is a diff from previous version.

No kernel is present on those images, and the purpose is for servers
to download those files by however means (http, ftp, scp, ...),
verify the files hash, and import them on their local zpool.