### PR TITLE
jails, git: remote may have updated branch non-fastfoward

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -582,7 +582,9 @@ install_from_vcs() {
 			echo " done"
 			;;
 		git*)
-			${GIT_CMD} -C ${SRC_BASE} pull --rebase -q || err 1 " fail"
+			${GIT_CMD} -C ${SRC_BASE} fetch -q || err 1 " fail"
+			${GIT_CMD} -C ${SRC_BASE} reset --hard origin/${VERSION} -q || err 1 " fail"
+			${GIT_CMD} -C ${SRC_BASE} clean -x -d -f -q || err 1 " fail"
 			if [ -n "${TORELEASE}" ]; then
 				${GIT_CMD} checkout -q "${TORELEASE}" || err 1 " fail"
 			fi

--- a/src/share/poudriere/ports.sh
+++ b/src/share/poudriere/ports.sh
@@ -385,7 +385,9 @@ if [ ${UPDATE} -eq 1 ]; then
 	git*)
 		msg_n "Updating portstree \"${PTNAME}\" with ${METHOD}..."
 		[ ${VERBOSE} -gt 0 ] || quiet="-q"
-		${GIT_CMD} -C ${PORTSMNT:-${PTMNT}} pull --rebase ${quiet}
+		${GIT_CMD} -C ${PORTSMNT:-${PTMNT}} fetch ${quiet}
+		${GIT_CMD} -C ${PORTSMNT:-${PTMNT}} reset --hard origin/${BRANCH} ${quiet}
+		${GIT_CMD} -C ${PORTSMNT:-${PTMNT}} clean -x -d -f ${quiet}
 		echo " done"
 		;;
 	null|none) msg "Not updating portstree \"${PTNAME}\" with method ${METHOD}" ;;


### PR DESCRIPTION
poudriere ports is expected to be the same as remote. If remote has
updated the objects in non-fast-forward mode (rebase, git push force, ...).
The pull will try to merge objects and will leave dirty merge markers.

This commits removes this behavior and tries to make the local clone
build the exact same objects as those in the remote repository.