### PR TITLE
Adjust "Known issues" style to match other headers

### DIFF
--- a/src/bin/poudriere.8
+++ b/src/bin/poudriere.8
@@ -311,7 +311,7 @@ The first (default) FLAVOR for a port is built by specifying the FLAVOR
 .Sy devel/foo@-
 .El
 .Pp
-.Ss KNOWN ISSUES
+.Ss Known issues
 .Bl -bullet -compat
 .It
 An invalid FLAVOR for a port will cause an error during dependency calculation.


### PR DESCRIPTION
All subsection headers are not written all in uppercase.