### PR TITLE
fs: fix unmount of directories in destroyfs

### DIFF
--- a/src/share/poudriere/include/fs.sh
+++ b/src/share/poudriere/include/fs.sh
@@ -349,7 +349,7 @@ destroyfs() {
 	local type="$2"
 	local fs
 
-	umountfs ${mnt} 1
+	umountfs ${mnt}
 	if [ ${TMPFS_ALL} -eq 1 ]; then
 		if [ -d "${mnt}" ]; then
 			if ! umount ${UMOUNT_NONBUSY} "${mnt}" 2>/dev/null; then


### PR DESCRIPTION
Current usage of umountfs by destroyfs is wrong. umountfs is currently
called with childonly set from destroyfs, which means that the path
provided in the first argument won't be unmounted, only the
mount points contained within. The code in destroyfs that follows the
call to umountfs will try to remove the directory passed to umountfs,
but that's likely not possible since the directory itself can be a
mount point.

Fix this by calling umountfs without childonly, and thus make sure the
path provided in the first parameter is unmounted.

Fixes: https://github.com/freebsd/poudriere/issues/654