### PR TITLE
fs: always use the real path as the cache identifier for zfs_getfs

### DIFF
--- a/src/share/poudriere/include/fs.sh
+++ b/src/share/poudriere/include/fs.sh
@@ -191,14 +191,15 @@ _zfs_getfs() {
 	[ $# -ne 1 ] && eargs _zfs_getfs mnt
 	local mnt="${1}"
 
-	mntres=$(realpath "${mnt}" 2>/dev/null || echo "${mnt}")
 	zfs list -rt filesystem -H -o name,mountpoint ${ZPOOL}${ZROOTFS} | \
-	    awk -vmnt="${mntres}" '$2 == mnt {print $1}'
+	    awk -vmnt="${mnt}" '$2 == mnt {print $1}'
 }
 
 zfs_getfs() {
 	[ $# -ne 1 ] && eargs zfs_getfs mnt
-	local mnt="${1}"
+	# NB: do the realpath call _before_ the cache call, so the cached value
+	# consistently uses the real path as the identifier.
+	local mnt=$(realpath "${1}" 2>/dev/null || echo "${1}")
 	local value
 
 	[ -n "${NO_ZFS}" ] && return 0


### PR DESCRIPTION
Perform the real path conversion in zfs_getfs so the cached value is
consistently using the real path as the identifier.

Without this fix poudriere doesn't work correctly when POUDRIERE_DATA
is set to a directory inside of /home for example, that has a real
path of /usr/home.

Fixes: https://github.com/freebsd/poudriere/issues/654