### PR TITLE
fix poudriere image since etc/login.conf.bak no more exist

### DIFF
--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -351,7 +351,6 @@ touch ${WRKDIR}/src.conf
 make -C ${mnt}/usr/src DESTDIR=${WRKDIR}/world BATCH_DELETE_OLD_FILES=yes SRCCONF=${WRKDIR}/src.conf delete-old delete-old-libs
 
 [ ! -d "${EXTRADIR}" ] || cp -fRPp ${EXTRADIR}/ ${WRKDIR}/world/
-mv ${WRKDIR}/world/etc/login.conf.orig ${WRKDIR}/world/etc/login.conf
 cap_mkdb ${WRKDIR}/world/etc/login.conf
 
 # Set hostname


### PR DESCRIPTION
With latest version I meet this error now:
```
 # poudriere image -j manual -t tar -n manual -h ""
[00:00:00] Preparing the image 'manual'
>>> Removing old files (only deletes safe to delete libs)
>>> Old files removed
>>> Removing old directories
>>> Old directories removed
To remove old libraries run 'make delete-old-libs'.
>>> Removing old libraries
Please be sure no application still uses those libraries, else you
can not start such an application. Consult UPDATING for more
information regarding how to cope with the removal/revision bump
of a specific library.
>>> Old libraries removed
mv: /usr/local/poudriere/data/images/manual-Sa6a/world/etc/login.conf.orig: No such file or directory
```

It seems world/etc/login.conf.orig didn't exist anymore, so use login.conf in place.