### PR TITLE
Add sleep, ls and ping to miniroot

### DIFF
--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -90,9 +90,9 @@ mkminiroot() {
 	dirs="etc dev boot bin usr/bin libexec lib usr/lib sbin"
 	files="sbin/init etc/pwd.db etc/spwd.db"
 	files="${files} bin/sh sbin/halt sbin/fasthalt sbin/fastboot sbin/reboot"
-	files="${files} usr/bin/bsdtar libexec/ld-elf.so.1 sbin/newfs"
+	files="${files} usr/bin/bsdtar libexec/ld-elf.so.1 sbin/newfs bin/sleep"
 	files="${files} sbin/mdconfig usr/bin/fetch sbin/ifconfig sbin/route sbin/mount"
-	files="${files} sbin/umount bin/mkdir bin/kenv usr/bin/sed"
+	files="${files} sbin/umount bin/mkdir bin/kenv usr/bin/sed sbin/ping bin/ls"
 
 	for d in ${dirs}; do
 		mkdir -p ${mroot}/${d}


### PR DESCRIPTION
My miniroot /etc/rc script configure network from kenv variable, then fetch full poudriere image using fetch.
But between these two step, we need to wait for the network interface to go UP: So we need "bin/sleep".
Other user would prefer to wait for a "ping -o": So sbin/ping seems useful too.
And the last one: "bin/ls", because trying to debug miniroot without being able to use 'ls' is frustrating.