### PR TITLE
on mutable base do not raise securelevel errors, fixes #684

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2354,8 +2354,8 @@ jail_start() {
 	if [ "${DISTFILES_CACHE}" != "no" -a ! -d "${DISTFILES_CACHE}" ]; then
 		err 1 "DISTFILES_CACHE directory does not exist. (cf.  poudriere.conf)"
 	fi
-	[ ${TMPFS_ALL} -ne 1 ] && [ $(sysctl -n kern.securelevel) -ge 1 ] && \
-	    err 1 "kern.securelevel >= 1. Poudriere requires no securelevel to be able to handle schg flags. USE_TMPFS=all can override this."
+	schg_immutable_base && [ $(sysctl -n kern.securelevel) -ge 1 ] && \
+	    err 1 "kern.securelevel >= 1. Poudriere requires no securelevel to be able to handle an immutable base (schg flags)."
 	[ "${name#*.*}" = "${name}" ] ||
 		err 1 "The jail name cannot contain a period (.). See jail(8)"
 	[ "${ptname#*.*}" = "${ptname}" ] ||


### PR DESCRIPTION
Poudriere needs to use schg flags when operating on MUTABLE_BASE, however
when the schg_immutable_base() function (which properly accounts for TMPFS_ALL
NO_ZFS and actual MUTABLE_BASE setting) was introduced the securelevel check
hasn't been altered to use it, instead only checking TMPFS_ALL setting.

This prevented poudriere from running, even in situations where the requested
task did not result in attempts to use schg flags.

Signed-off-by: Adam Wolk <a.wolk@fudosecurity.com>