### PR TITLE
Add DISALLOW_NETWORKING, fixes #689

### DIFF
--- a/src/etc/poudriere.conf.sample
+++ b/src/etc/poudriere.conf.sample
@@ -149,6 +149,12 @@ DISTFILES_CACHE=/usr/ports/distfiles
 #RESTRICT_NETWORKING=yes
 #ALLOW_NETWORKING_PACKAGES="npm-foo"
 
+# Networking can be fully disabled by setting DISALLOW_NETWORKING to "yes"
+# this will prevent networking access even in the 'make fetch' phase
+# and will block access even for packages listed in ALLOW_NETWORKING_PACKAGES.
+# Default: no
+#DISALLOW_NETWORKING=yes
+
 # parallel build support.
 #
 # By default poudriere uses hw.ncpu to determine the number of builders.

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -536,6 +536,10 @@ do_confirm_delete() {
 }
 
 injail() {
+	if [ "${DISALLOW_NETWORKING}" = "yes" ]; then
+	    local JNETNAME=
+	fi
+
 	if [ ${INJAIL_HOST:-0} -eq 1 ]; then
 		# For test/
 		"$@"
@@ -553,6 +557,10 @@ injail() {
 
 injail_tty() {
 	local name
+
+	if [ "${DISALLOW_NETWORKING}" = "yes" ]; then
+	    local JNETNAME=
+	fi
 
 	_my_name name
 	[ -n "${name}" ] || err 1 "No jail setup"
@@ -7779,6 +7787,7 @@ fi
 : ${PORTTESTING_RECURSIVE:=0}
 : ${PRIORITY_BOOST_VALUE:=99}
 : ${RESTRICT_NETWORKING:=yes}
+: ${DISALLOW_NETWORKING:=no}
 : ${TRIM_ORPHANED_BUILD_DEPS:=yes}
 : ${USE_JEXECD:=no}
 : ${USE_PROCFS:=yes}


### PR DESCRIPTION
Networking can be fully disabled by setting DISALLOW_NETWORKING to "yes"
this will prevent networking access even in the 'make fetch' phase
and will block access even for packages listed in ALLOW_NETWORKING_PACKAGES.

The new option defaults to "no".

Previously when running bulk builds, any missing distfiles were automatically
fetched over the network with no way to disable such behavior.

Signed-off-by: Adam Wolk <a.wolk@fudosecurity.com>