### PR TITLE
testport.sh: Fix make.conf not being respected

### DIFF
--- a/src/share/poudriere/testport.sh
+++ b/src/share/poudriere/testport.sh
@@ -216,6 +216,7 @@ if [ $CONFIGSTR -eq 1 ]; then
 	    make -C ${portsdir}/${ORIGIN} \
 	    ${FLAVOR:+FLAVOR=${FLAVOR}} \
 	    config
+	rm ${__MAKE_CONF}
 fi
 
 # deps_fetch_vars lookup for dependencies moved to prepare_ports()

--- a/src/share/poudriere/testport.sh
+++ b/src/share/poudriere/testport.sh
@@ -205,11 +205,10 @@ fi
 injail /usr/bin/make -C ${PORTSDIR}/${ORIGIN} maintainer ECHO_CMD=true || \
     err 1 "Port is broken"
 
-__MAKE_CONF=$(mktemp -t poudriere-make.conf)
-setup_makeconf ${__MAKE_CONF} "${JAILNAME}" "${PTNAME}" "${SETNAME}"
-
 if [ $CONFIGSTR -eq 1 ]; then
 	command -v dialog4ports >/dev/null 2>&1 || err 1 "You must have ports-mgmt/dialog4ports installed on the host to use -c."
+	__MAKE_CONF=$(mktemp -t poudriere-make.conf)
+	setup_makeconf ${__MAKE_CONF} "${JAILNAME}" "${PTNAME}" "${SETNAME}"
 	PORTSDIR=${portsdir} \
 	    __MAKE_CONF=${__MAKE_CONF} \
 	    PORT_DBDIR=${MASTERMNT}/var/db/ports \

--- a/src/share/poudriere/testport.sh
+++ b/src/share/poudriere/testport.sh
@@ -205,10 +205,13 @@ fi
 injail /usr/bin/make -C ${PORTSDIR}/${ORIGIN} maintainer ECHO_CMD=true || \
     err 1 "Port is broken"
 
+__MAKE_CONF=$(mktemp -t poudriere-make.conf)
+setup_makeconf ${__MAKE_CONF} "${JAILNAME}" "${PTNAME}" "${SETNAME}"
+
 if [ $CONFIGSTR -eq 1 ]; then
 	command -v dialog4ports >/dev/null 2>&1 || err 1 "You must have ports-mgmt/dialog4ports installed on the host to use -c."
 	PORTSDIR=${portsdir} \
-	    __MAKE_CONF=/dev/null \
+	    __MAKE_CONF=${__MAKE_CONF} \
 	    PORT_DBDIR=${MASTERMNT}/var/db/ports \
 	    TERM=${SAVED_TERM} \
 	    make -C ${portsdir}/${ORIGIN} \


### PR DESCRIPTION
Currently, `testport -c` does not honour make.confs such as can be set
in `poudriere.d/{*-}make.conf` files, because the `__MAKE_CONF` variable [1]
is set to /dev/null, introduced in a43fe7cb to fix #545.

Accordingly, when using testport -c, when dialog4ports is run, it presents
information that does not match what is actually used/built because the
expected make environment(s) configurations are not used.

For example, this issue was identified while testing the www/py-autobahn
port, and make config (dialog4ports) was incorrectly displaying
py36-autobahn and py36 specific OPTIONS, when testport was in fact
building py27-autobahn and py27 specific OPTIONS (correctly) via -zpy27,
which contained a DEFAULT_VERSIONS=python=2.7 override.

The issue is not limited to package names and OPTIONS, but anything that
needs to take effect or be modified in the config target.

Conversely, the options command introduced a fix to "Fix make.conf not
being respected in 2d9b712b, introducing a `setup_makeconf()` function in
common.sh that constructs a `make.conf` based on global, tree, and set
specific make.conf's, if they are set.

This change utilises the `setup_makeconf()` function in common.sh, and
applies it to testport.sh to correctly respect make.confs when -c is used.

I have tested this locally with a patch against ports-mgmt/poudriere-devel
and confirmed that it correctly finds and appends all relevant make.confs,
and presents information in dialog4ports that is correct, and matches what
is used and built during the testport.

I wasn't sure whether the following CLEANUP_HOOK from options.sh also
needed to be replicated in testport.sh:

```
CLEANUP_HOOK=options_cleanup
options_cleanup() {
    rm -f ${__MAKE_CONF}
}
```

If it does, let me know and I'll that that to the PR

[1] man make.conf