### PR TITLE
warn if MFSROOT may be too large

### DIFF
--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -489,6 +489,8 @@ case ${MEDIATYPE} in
 	case "${MEDIATYPE}" in
 	*zmfs) ${GZCMD:-gzip} -9 ${WRKDIR}/out/mfsroot ;;
 	esac
+	MFSROOTSIZE=$(ls -l ${WRKDIR}/out/mfsroot* | head -n 1 | awk '{print $5}')
+	if [ ${MFSROOTSIZE} -ge 268435456 ]; then echo WARNING: MFSROOT too large, boot failure likely ; fi
 	cpdup -i0 ${WRKDIR}/world/boot ${WRKDIR}/out/boot
 	cat >> ${WRKDIR}/out/boot/loader.conf <<-EOF
 	tmpfs_load="YES"


### PR DESCRIPTION
While using poudriere-image(8) I've run into issues where the boot loader fails to load the mfsroot is too large. The maximum workable size seems to be 256mb, so add a warning to the user about this.

FWIW, adding these lines to the src.conf used to build the jail let's me get a small enough jail that the image boots for CURRENT:

```
WITHOUT_BINUTILS=yes
WITHOUT_CLANG_EXTRAS=yes
WITHOUT_CLANG_FULL=yes
WITHOUT_CLANG=yes
WITHOUT_CXX=yes
WITHOUT_DEBUG_FILES=yes
WITHOUT_DTRACE_TESTS=yes
WITHOUT_GDB=yes
WITHOUT_GNUCXX=yes
WITHOUT_KERNEL_SYMBOLS=yes
WITHOUT_LIB32=yes
WITHOUT_LLD=yes
WITHOUT_LLDB=yes
WITHOUT_LLVM_COV=yes
WITHOUT_MAN_UTILS=yes
WITHOUT_MAN=yes
WITHOUT_MANCOMPRESS=yes
WITHOUT_TESTS=yes
```

Of course, you can't build packages with this, but if you build another jail with the same version without those src.conf settings and symlink the jail name, it works great. Not sure if this warrants adding to the docs or where that would go, but for now let's at least give the user a hint why their image is failing to boot.