### PR TITLE
Reinstate save_cfg

### DIFF
--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -557,6 +557,8 @@ usb)
 		rm -rf ${WRKDIR}/world/usr/local/etc
 		ln -s /etc/local ${WRKDIR}/world/usr/local/etc
 	fi
+	# Copy save_cfg to /etc
+	cp ${mnt}/usr/src/tools/tools/nanobsd/Files/root/save_cfg ${WRKDIR}/world/etc/
 	# Copy /etc and /var to /conf/base as "reference"
 	for d in var etc; do
 		mkdir -p ${WRKDIR}/world/conf/base/$d ${WRKDIR}/world/conf/default/$d
@@ -569,9 +571,6 @@ usb)
 	# replace /tmp by a symlink to /var/tmp
 	rm -rf ${WRKDIR}/world/tmp
 	ln -s /var/tmp ${WRKDIR}/world/tmp
-
-	# Copy save_cfg to /etc
-	cp ${mnt}/usr/src/tools/tools/nanobsd/Files/root/save_cfg ${WRKDIR}/world/etc/
 
 	# Figure out Partition sizes
 	OS_SIZE=


### PR DESCRIPTION
After 9123631e47f9017f9a3f3de4362eea631179205a, `save_cfg` does not end in the final image, as inteded by 28604ac2492c1c61f3ac83d8812bc3d7cfdaa378.  I'm not sure if this was intentional given what is written in the comments.  Or should it be removed completely?