### PR TITLE
Add documentation about OPTIONS_(UNSET|SET)

### DIFF
--- a/src/bin/poudriere-options.8
+++ b/src/bin/poudriere-options.8
@@ -93,6 +93,17 @@ in
 .Xr poudriere 8
 for examples of how this is used.
 .El
+.Sh DEFAULT OPTIONS
+It is possible to enable or disable options by default using
+.Va OPTIONS_SET
+and
+.Va OPTIONS_UNSET
+respectively, in one of the poudriere's
+.Pa make.conf .
+.Pp
+See
+.Xr poudriere 8
+for more details.
 .Sh SEE ALSO
 .Xr poudriere 8 ,
 .Xr poudriere-bulk 8 ,


### PR DESCRIPTION
I propose a friendly documentation about default options which are only documented in /usr/ports/Mk/bsd.port.mk which users may not have since poudriere handles ports by itself as a "black-box"