### PR TITLE
Refine the regular expression

### DIFF
--- a/src/share/poudriere/awk/json_jail.awk
+++ b/src/share/poudriere/awk/json_jail.awk
@@ -34,7 +34,7 @@ function print_build(buildname, data) {
     print "\"" buildname "\":" data "" | "sort -n -k1,1 -t :"
 }
 {
-  if (FILENAME ~ /latest\//)
+  if (FILENAME ~ /\/latest\//)
     next
   else {
     data = $0


### PR DESCRIPTION
I came across a small bug. If you call the ports collection "latest", the view of all builds of a master is empty in the web interface. A short research showed that this happens through the AWK script "src/share/poudriere/awk/json_jail.awk".
This script filters out all log directories ending with "...latest/". If, as in my case, I have named the ports like this, the script filters out all logs. (Jail: "amd64-12-1", Ports: "latest" makes buildname "amd64-12-1-latest")
My small change in this pull request improves the behavior. For me, it now works as I expect it to. Please note, I have not done great testing with this change.