### PR TITLE
Clean up the svn/git repository after updating a jail to a newer vers…

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -580,6 +580,7 @@ install_from_vcs() {
 			msg_n "Updating the sources with ${METHOD}..."
 			${SVN_CMD} upgrade ${SRC_BASE} 2>/dev/null || :
 			${SVN_CMD} -q update -r ${TORELEASE:-head} ${SRC_BASE} || err 1 " fail"
+			${SVN_CMD} cleanup ${SRC_BASE} || err 1 " fail"
 			echo " done"
 			;;
 		git*)
@@ -587,6 +588,7 @@ install_from_vcs() {
 			if [ -n "${TORELEASE}" ]; then
 				${GIT_CMD} checkout -q "${TORELEASE}" || err 1 " fail"
 			fi
+			(cd ${SRC_BASE} && ${GIT_CMD} gc) || err 1 " fail"
 			echo " done"
 			;;
 		esac


### PR DESCRIPTION
…ion.

Updating a jail to a newer version grows the .svn / .git metadata folder.
Compact it after updating and before taking a new @clean snapshot to
keep the size down.

It is unlikely that people will modify these checkouts by themselves. A
patch can be used for this when using svn and git supoprts feature branches
for this.

(WIP) Perhaps this needs a new knob in poudriere.conf.
(WIP) Perhaps we want to be more aggressive in the cleanup method.