### PR TITLE
Fix permissions on the .json files

### DIFF
--- a/src/share/poudriere/include/util.sh
+++ b/src/share/poudriere/include/util.sh
@@ -993,6 +993,7 @@ write_cmp() {
 	fi
 
 	if ! cmp -s "${dest}" "${tmp}"; then
+		chmod 644 ${tmp}
 		rename "${tmp}" "${dest}"
 	else
 		unlink "${tmp}"


### PR DESCRIPTION
Without this the webUI does not work.

I don't really like this, but `mktemp` does not seem to have a way to set the perms when it creates the file.  I suppose we could use `umask` instead.. Thoughts?