### PR TITLE
Add support for fetching from artifact.ci.freebsd.org

### DIFF
--- a/src/bin/poudriere-jail.8
+++ b/src/bin/poudriere-jail.8
@@ -212,6 +212,9 @@ Fetch from
 .It Cm http
 See
 .Cm ftp .
+.It Cm freebsdci
+Fetch from
+.Lk https://artifact.ci.freebsd.org .
 .It Cm null
 This option can be used to import an existing directory that already contains
 an installed system.

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -58,8 +58,8 @@ Options:
     -m method     -- When used with -c, overrides the default method for
                      obtaining and building the jail. See poudriere(8) for more
                      details. Can be one of:
-                       allbsd, ftp-archive, ftp, git, http, null, src=PATH, svn,
-                       svn+file, svn+http, svn+https, svn+ssh, tar=PATH
+                       allbsd, ftp-archive, ftp, freebsdci, git, http, null, src=PATH,
+                       svn, svn+file, svn+http, svn+https, svn+ssh, tar=PATH
                        url=SOMEURL.
     -P patch      -- Specify a patch to apply to the source before building.
     -S srcpath    -- Specify a path to the source tree to be used.
@@ -342,7 +342,7 @@ update_jail() {
 		make -C ${SRC_BASE} delete-old delete-old-libs DESTDIR=${JAILMNT} BATCH_DELETE_OLD_FILES=yes
 		markfs clean ${JAILMNT}
 		;;
-	allbsd|gjb|url=*)
+	allbsd|gjb|url=*|freebsdci)
 		[ -z "${VERSION}" ] && VERSION=$(jget ${JAILNAME} version)
 		[ -z "${ARCH}" ] && ARCH=$(jget ${JAILNAME} arch)
 		delete_jail
@@ -678,6 +678,7 @@ install_from_ftp() {
 		url=*) URL=${METHOD##url=} ;;
 		allbsd) URL="https://pub.allbsd.org/FreeBSD-snapshots/${ARCH%%.*}-${ARCH##*.}/${V}-JPSNAP/ftp" ;;
 		ftp-archive) URL="http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/${ARCH}/${V}" ;;
+		freebsdci) URL="https://artifact.ci.freebsd.org/snapshot/${V}/latest_tested/${ARCH%%.*}/${ARCH##*.}" ;;
 		esac
 		DISTS="${DISTS} dict"
 		[ "${NO_LIB32:-no}" = "no" -a "${ARCH}" = "amd64" ] &&
@@ -740,6 +741,7 @@ install_from_ftp() {
 				;;
 			allbsd) URL="https://pub.allbsd.org/FreeBSD-snapshots/${ARCH%%.*}-${ARCH##*.}/${V}-JPSNAP/ftp" ;;
 			ftp-archive) URL="http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/${ARCH%%.*}/${ARCH##*.}/${V}" ;;
+			freebsdci) URL="https://artifact.ci.freebsd.org/snapshot/${V}/latest_tested/${ARCH%%.*}/${ARCH##*.}" ;;
 			url=*) URL=${METHOD##url=} ;;
 		esac
 
@@ -824,7 +826,7 @@ create_jail() {
 	fi
 
 	case ${METHOD} in
-	ftp|http|gjb|ftp-archive|url=*)
+	ftp|http|gjb|ftp-archive|freebsdci|url=*)
 		FCT=install_from_ftp
 		;;
 	allbsd)


### PR DESCRIPTION
This adds a new method -m freebsdci which fetches the latest tested sets
from the CI artifacts.
Sometimes head or stable doesn't compile and we waste time and power starting
building a jail to see later that it fails.
This also make it possible to create an armv7 jail from latest tested head which
isn't possible using the ftp method as re@ doesn't publish sets.

Signed-off-by: Emmanuel Vadot <manu@FreeBSD.org>