### PR TITLE
Adding new bulk command option: -W to mount ports tree in read-write …

### DIFF
--- a/src/bin/poudriere-bulk.8
+++ b/src/bin/poudriere-bulk.8
@@ -243,6 +243,8 @@ The
 .Va WRKDIR
 will be tarred up into
 .No ${ Ns Va POUDRIERE_DATA Ns } Ns Pa /wrkdirs .
+.It Fl W
+Mount ports tree in read-write mode, allowing to patch it in interactive mode.
 .It Fl z Ar set
 This specifies which SET to use for the build.
 See the

--- a/src/share/poudriere/bulk.sh
+++ b/src/share/poudriere/bulk.sh
@@ -69,6 +69,8 @@ Options:
     -v          -- Be verbose; show more information. Use twice to enable
                    debug output
     -w          -- Save WRKDIR on failed builds
+    -W          -- Mount ports tree in read-write mode (allowing to patch
+                   it in interactive mode)
     -z set      -- Specify which SET to use
 EOF
 	exit 1
@@ -88,11 +90,12 @@ ALL=0
 BUILD_REPO=1
 INTERACTIVE_MODE=0
 OVERLAYS=""
+PORTS_SRC_RW=0
 . ${SCRIPTPREFIX}/common.sh
 
 [ $# -eq 0 ] && usage
 
-while getopts "aB:CcFf:iIj:J:knNO:p:RrSTtvwz:" FLAG; do
+while getopts "aB:CcFf:iIj:J:knNO:p:RrSTtvwWz:" FLAG; do
 	case "${FLAG}" in
 		a)
 			ALL=1
@@ -175,6 +178,9 @@ while getopts "aB:CcFf:iIj:J:knNO:p:RrSTtvwz:" FLAG; do
 			;;
 		w)
 			SAVE_WRKDIR=1
+			;;
+		W)
+			PORTS_SRC_RW=1
 			;;
 		z)
 			[ -n "${OPTARG}" ] || err 1 "Empty set name"

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -1876,7 +1876,8 @@ do_portbuild_mounts() {
 	_pget portsdir ${ptname} mnt || err 1 "Missing mnt metadata for portstree"
 	[ -d ${portsdir}/ports ] && portsdir=${portsdir}/ports
 	${msgmount} "Mounting ports from: ${portsdir}"
-	${NULLMOUNT} -o ro ${portsdir} ${mnt}${PORTSDIR} ||
+	[ ${PORTS_SRC_RW} -eq 1 ] && OPT=rw || OPT=ro
+	${NULLMOUNT} -o ${OPT} ${portsdir} ${mnt}${PORTSDIR} ||
 		err 1 "Failed to mount the ports directory "
 	for o in ${OVERLAYS}; do
 		_pget odir "${o}" mnt || err 1 "Missing mnt metadata for overlay ${o}"


### PR DESCRIPTION
…mode,

allowing to patch the port tree in interactive mode.

Interactive mode is used to troubleshoot a port build, so being able to use a `make makepatch` from it seems useful.