### PR TITLE
Allow overlay to reinstate a port.

### DIFF
--- a/src/share/poudriere/awk/parse_MOVED.awk
+++ b/src/share/poudriere/awk/parse_MOVED.awk
@@ -64,16 +64,25 @@ BEGIN {
 		{ printf("MOVED error: %s has duplicate entries\n", src) > "/dev/stderr" }
 		next
 	}
-	refname[ref] = src
-	forward[ref] = dst
-	srcs[src] = ref
-	if (dst == "")
-		reason[ref] = $3 " " $4
-	#printf("READ %s %s -> %s\n", src, ref, dst)
+	if (src == "") {
+		if (dst in srcs) {
+			delete forward[srcs[dst]]
+			delete refname[srcs[dst]]
+			delete srcs[dst]
+		}
+	}
+	else {
+		refname[ref] = src
+		forward[ref] = dst
+		srcs[src] = ref
+		if (dst == "")
+			reason[ref] = $3 " " $4
+		#printf("READ %s %s -> %s\n", src, ref, dst)
 
-	# Update fowards to me to now point to my dst and
-	# update my own backrefs
-	update_forwards(src, ref)
+		# Update fowards to me to now point to my dst and
+		# update my own backrefs
+		update_forwards(src, ref)
+	}
 }
 
 END {

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -7060,8 +7060,13 @@ load_moved() {
 	[ -f ${MASTERMNT}${PORTSDIR}/MOVED ] || return 0
 	msg "Loading MOVED for ${MASTERMNT}${PORTSDIR}"
 	bset status "loading_moved:"
-	awk -f ${AWKPREFIX}/parse_MOVED.awk \
-	    ${MASTERMNT}${PORTSDIR}/MOVED | \
+        { cat ${MASTERMNT}${PORTSDIR}/MOVED 
+          for o in ${OVERLAYS}; do
+                 test -f "${MASTERMNT}${OVERLAYSDIR}/${o}/MOVED" || continue
+                 cat "${MASTERMNT}${OVERLAYSDIR}/${o}/MOVED"
+          done
+        } | \
+	awk -f ${AWKPREFIX}/parse_MOVED.awk | \
 	    while mapfile_read_loop_redir old_origin new_origin; do
 		# new_origin may be EXPIRED followed by the reason
 		# or only a new origin.


### PR DESCRIPTION
This update allows an overlay to reinstate a port with a MOVED entry. It applies the following convention to reinstate a deleted origin:

`old name (blank for reinstated)|new name|date of move|reason`

MOVED files from overlays are effectively appended to the MOVED file from the base repo. This is possibly incorrect for any use except simple reinstatement. 