### PR TITLE
Test by == instead of awk match for port completion

### DIFF
--- a/completions/bash/poudriere
+++ b/completions/bash/poudriere
@@ -64,7 +64,7 @@ _poudriere_direct_port() {
     elif [[ -z $ports_tree ]]; then
         return
     fi
-    local ports_tree_path="$(poudriere ports -l | awk -v tree=$ports_tree 'NR > 1{if (match($1, tree)) {print $5}}')"
+    local ports_tree_path="$(poudriere ports -l | awk -v tree=$ports_tree 'NR > 1{if ($1 == tree) {print $5}}')"
     # Complete port name.
     if [[ $cur =~ .*/.* ]]; then
         COMPREPLY=($(compgen -W "$(


### PR DESCRIPTION
If a tree has a sub-string in another tree's name ports_tree_path could
have a multiple return value.  Test the tree with 'poudriere ports -l'
first column by an exact match.