### PR TITLE
Include poudriere options in usage.

### DIFF
--- a/src/bin/poudriere.in
+++ b/src/bin/poudriere.in
@@ -44,7 +44,7 @@ env_export() {
 
 usage() {
 	cat << EOF
-Usage: poudriere [-e etcdir] [-N] command [options]
+Usage: poudriere [-ANv] [-e etcdir] command [options]
 
 Options:
     -A          -- Force colors, even if not in a TTY


### PR DESCRIPTION
Rather than just listing `-e <etcdir>` list all the options for consistency. If there are ever too many, we can fall back to listing them as [poudriere-options] like the manpage.