### PR TITLE
Always use fully qualified arch in test suite jail creation.

### DIFF
--- a/test/common.bulk.sh
+++ b/test/common.bulk.sh
@@ -583,7 +583,7 @@ if [ -z "${JAILMNT}" ]; then
 	fi
 	echo "Setting up jail for testing..." >&2
 	if ! ${SUDO} ${POUDRIERE} jail -c -j "${JAILNAME}" \
-	    -v "${JAIL_VERSION}" -a ${ARCH}; then
+	    -v "${JAIL_VERSION}" -a "$(uname -m).${ARCH}"; then
 		echo "SKIP: Cannot setup jail with Poudriere" >&2
 		exit 77
 	fi


### PR DESCRIPTION
This allows me to successfully run `make check` on powerpc.powerpc64. (Without this, it tries to download the base system from an invalid path.)