### PR TITLE
Add new pkg repo file hash ability to poudriere.conf Default to off

### DIFF
--- a/src/etc/poudriere.conf.sample
+++ b/src/etc/poudriere.conf.sample
@@ -309,3 +309,13 @@ DISTFILES_CACHE=/usr/ports/distfiles
 # processing of the queue slightly, especially for bulk -a builds.
 # Default: no
 #HTML_TRACK_REMAINING=yes
+
+# Have pkg create hashed versions of the pkg filenames with symlinks to
+# original pkg names. The packagesite.yaml file will point to the hashed version
+# of these files. By using hashed pkg filenames, this allows users to lazily
+# synchronise packages without conflicting with the current packages,
+# for example using rsync or CDNs.  Once the packages are synced the much
+# smaller meta files can then be synced. Allowing a near atomic update of repo.
+# On caching cdn this means a need to purge 2-5 files instead of all pkgs that
+# have been updated.
+#PKG_HASH=no

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -7664,6 +7664,9 @@ build_repo() {
 	local origin
 
 	msg "Creating pkg repository"
+	if [ ${PKG_HASH} != no ] ; then
+	REPO_OPTIONS="-h -s"
+	fi
 	[ ${DRY_RUN} -eq 1 ] && return 0
 	bset status "pkgrepo:"
 	ensure_pkg_installed force_extract || \
@@ -7680,7 +7683,7 @@ build_repo() {
 	if [ -n "${PKG_REPO_SIGNING_KEY}" ]; then
 		install -m 0400 ${PKG_REPO_SIGNING_KEY} \
 			${MASTERMNT}/tmp/repo.key
-		injail ${PKG_BIN} repo -o /tmp/packages \
+		injail ${PKG_BIN} repo ${REPO_OPTIONS} -o /tmp/packages \
 			${PKG_META} \
 			/packages /tmp/repo.key
 		unlink ${MASTERMNT}/tmp/repo.key
@@ -7688,12 +7691,12 @@ build_repo() {
 		# Sometimes building repo from host is needed if
 		# using SSH with DNSSEC as older hosts don't support
 		# it.
-		${MASTERMNT}${PKG_BIN} repo \
+		${MASTERMNT}${PKG_BIN} repo ${REPO_OPTIONS} \
 		    -o ${MASTERMNT}/tmp/packages ${PKG_META_MASTERMNT} \
 		    ${MASTERMNT}/packages \
 		    ${SIGNING_COMMAND:+signing_command: ${SIGNING_COMMAND}}
 	else
-		JNETNAME="n" injail ${PKG_BIN} repo \
+		JNETNAME="n" injail ${PKG_BIN} repo  ${REPO_OPTIONS}\
 		    -o /tmp/packages ${PKG_META} /packages \
 		    ${SIGNING_COMMAND:+signing_command: ${SIGNING_COMMAND}}
 	fi
@@ -8102,6 +8105,7 @@ if [ "$(mount -t fdescfs | awk '$3 == "/dev/fd" {print $3}')" = "/dev/fd" ]; the
 fi
 
 : ${OVERLAYSDIR:=/overlays}
+: ${PKG_HASH:=no}
 
 TIME_START=$(clock -monotonic)
 EPOCH_START=$(clock -epoch)


### PR DESCRIPTION
@allanjude  Here's an initial addition to poudriere. Do you think it makes sense to expose both hash and symlink ability or just default to creating symlink if your appending hash to package name

If anyone has a prefered method to a poudriere.conf variable Please let me know

@allanjude  Also any help on wording for poudriere.conf comment would be appreciated