### PR TITLE
Improve overlay support

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -801,7 +801,7 @@ _lookup_portdir() {
 
 	for o in ${OVERLAYS}; do
 		_ptdir="${OVERLAYSDIR}/${o}/${_port}"
-		if [ -d "${MASTERMNTREL}${_ptdir}" ]; then
+		if [ -r "${MASTERMNTREL}${_ptdir}/Makefile" ]; then
 			setvar "${_varname}" "${_ptdir}"
 			return
 		fi


### PR DESCRIPTION
Allow testport to work with an origin in an overlay.

Tighten the parameters on selecting an overlay directory as an origin.