### PR TITLE
Add an example of MAKEWORLDARGS

### DIFF
--- a/src/etc/poudriere.conf.sample
+++ b/src/etc/poudriere.conf.sample
@@ -309,3 +309,7 @@ DISTFILES_CACHE=/usr/ports/distfiles
 # processing of the queue slightly, especially for bulk -a builds.
 # Default: no
 #HTML_TRACK_REMAINING=yes
+
+# Set to pass arguments to buildworld.
+# Defualt:
+#MAKEWORLDARGS="WITHOUT_LLVM_ASSERTIONS=yes WITH_MALLOC_PRODUCTION=yes -DMALLOC_PRODUCTION"


### PR DESCRIPTION
It took me quite a bit of grepping to find this otherwise undocumented feature. We might even consider enabling the example settings by default.