### PR TITLE
Define regular expression more precisely

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -176,7 +176,7 @@ update_version() {
 	local version_extra="$1"
 
 	if [ -r "${SRC_BASE}/sys/conf/newvers.sh" ]; then
-		eval `grep "^[RB][A-Z]*=" ${SRC_BASE}/sys/conf/newvers.sh `
+		eval `grep "^REVISION=\|^BRANCH=" ${SRC_BASE}/sys/conf/newvers.sh `
 		RELEASE=${REVISION}-${BRANCH}
 	else
 		RELEASE=$(jget ${JAILNAME} version)


### PR DESCRIPTION
Here is a jail update run for 12.1-RELEASE:
```
# /usr/local/bin/poudriere jail -u -j amd64-12-1
[00:00:00] Upgrading using ftp
/etc/resolv.conf -> /usr/local/poudriere/jails/amd64-12-1/etc/resolv.conf
Looking up update.FreeBSD.org mirrors... 3 mirrors found.
Fetching metadata signature for 12.1-RELEASE from update2.freebsd.org... done.
Fetching metadata index... done.
Inspecting system... done.
Preparing to download files... done.

No updates needed to update system to 12.1-RELEASE-p10.
12.1-RELEASE-p10
[00:00:26] Recording filesystem state for clean... done
```
And here is a run for 12.2-RELEASE
```
# /usr/local/bin/poudriere jail -u -j amd64-12-2
[00:00:00] Upgrading using ftp
/etc/resolv.conf -> /usr/local/poudriere/jails/amd64-12-2/etc/resolv.conf
Looking up update.FreeBSD.org mirrors... 3 mirrors found.
Fetching metadata signature for 12.2-RELEASE from update4.freebsd.org... failed.
Fetching metadata signature for 12.2-RELEASE from update2.freebsd.org... done.
Fetching metadata index... done.
Inspecting system... done.
Preparing to download files... done.

No updates needed to update system to 12.2-RELEASE-p0.
awk: can't open file /sys/param.h
 source line number 1
12.2-RELEASE
[00:00:02] Recording filesystem state for clean... done
```
There is a difference in the second one. `awk` tells that the file `/sys/param.h` cannot be opened.

I think this is a bug. In the function "update_version" the release number and the branch is read from the file "newvers.sh". Between the two releases (12.1 and 12.2) the structure of the file "newvers.sh" has changed a bit.
Apparently it happens that the regular expression in line 179 returns too much.
Compare
```
% grep "^[RB][A-Z]*=" /usr/local/poudriere/jails/amd64-12-1/usr/src/sys/conf/newvers.sh
REVISION="12.1" 
BRANCH="RELEASE-p10" 
RELEASE="${REVISION}-${BRANCH}"
```
with
```
% grep "^[RB][A-Z]*=" /usr/local/poudriere/jails/amd64-12-2/usr/src/sys/conf/newvers.sh
REVISION="12.2"
BRANCH="RELEASE"
RELEASE="${REVISION}-${BRANCH}"
RELDATE=$(awk '/__FreeBSD_version.*propagated to newvers/ {print $3}' ${PARAMFILE:-${SYSDIR}/sys/param.h})
```
.
Now my proposal is to modify the regular expression to take only the two desired values.
```
% grep "^REVISION=\|^BRANCH=" /usr/local/poudriere/jails/amd64-12-1/usr/src/sys/conf/newvers.sh                 
REVISION="12.1"
BRANCH="RELEASE-p10"
```
My change shows the desired effect on my computer, namely that the message of awk does not appear anymore. However I cannot estimate, if this change has side effects. So, please check this.