### PR TITLE
bulk: allow prefetching binary packages from official repos

### DIFF
--- a/src/bin/poudriere-bulk.8
+++ b/src/bin/poudriere-bulk.8
@@ -40,6 +40,7 @@
 .Fl a
 .Fl j Ar name
 .Op Fl CcFIikNnRrSTtvw
+.Op Fl b Ar name
 .Op Fl B Ar name
 .Op Fl J Ar maxjobs Ns Op Cm \&: Ns Ar prebuildmaxjobs
 .Op Fl O Ar overlays
@@ -50,6 +51,7 @@
 .Fl f Ar file Op Oo Fl f Ar file2 Oc Ar ...
 .Fl j Ar name
 .Op Fl CcFIikNnRrSTtvw
+.Op Fl b Ar name
 .Op Fl B Ar name
 .Op Fl J Ar maxjobs Ns Op Cm \&: Ns Ar prebuildmaxjobs
 .Op Fl O Ar overlays
@@ -59,6 +61,7 @@
 .Cm bulk
 .Fl j Ar name
 .Op Fl CcFIikNnRrSTtvw
+.Op Fl b Ar name
 .Op Fl B Ar name
 .Op Fl J Ar maxjobs Ns Op Cm \&: Ns Ar prebuildmaxjobs
 .Op Fl O Ar overlays
@@ -111,6 +114,17 @@ arguments may be specified at once.
 .El
 .Sh OPTIONS
 .Bl -tag -width "-B name"
+.It Fl b Ar name
+Specify the
+.Ar name
+of the binary package branch to use to prefetch packages.
+Should be
+.Qq latest
+or
+.Qq quarterly .
+With this option poudriere will first try to fetch from the binary package
+repository specified the binary package prior to do the sanity check if the
+package does not already exist.
 .It Fl B Ar name
 Specify which buildname to use.
 By default

--- a/src/bin/poudriere-bulk.8
+++ b/src/bin/poudriere-bulk.8
@@ -141,6 +141,13 @@ is used along with
 or
 .Fl c ,
 then listed packages will not be fetched.
+.Pp
+See
+.Sy PACKAGE_FETCH_BRANCH ,
+and
+.Sy PACKAGE_FETCH_URL ,
+in
+.Pa poudriere.conf.sample .
 .It Fl C
 Clean only the packages specified on the command line or in the file given by
 .Fl f Ar file .

--- a/src/bin/poudriere-bulk.8
+++ b/src/bin/poudriere-bulk.8
@@ -119,9 +119,10 @@ Specify the
 .Ar name
 of the binary package branch to use to prefetch packages.
 Should be
-.Qq latest
+.Qq latest ,
+.Qq quarterly ,
 or
-.Qq quarterly .
+.Qq release_* .
 With this option poudriere will first try to fetch from the binary package
 repository specified the binary package prior to do the sanity check if the
 package does not already exist.

--- a/src/bin/poudriere-bulk.8
+++ b/src/bin/poudriere-bulk.8
@@ -114,6 +114,13 @@ arguments may be specified at once.
 .El
 .Sh OPTIONS
 .Bl -tag -width "-B name"
+.It Fl B Ar name
+Specify which buildname to use.
+By default
+.Ar YYYY-MM-DD_HH:MM:SS
+will be used.
+This can be used to resume a previous build and use the same log and URL paths.
+Resuming a build will not retry built/failed/skipped/ignored packages.
 .It Fl b Ar name
 Specify the
 .Ar name
@@ -133,13 +140,6 @@ is used along with
 or
 .Fl c ,
 then listed packages will not be fetched.
-.It Fl B Ar name
-Specify which buildname to use.
-By default
-.Ar YYYY-MM-DD_HH:MM:SS
-will be used.
-This can be used to resume a previous build and use the same log and URL paths.
-Resuming a build will not retry built/failed/skipped/ignored packages.
 .It Fl C
 Clean only the packages specified on the command line or in the file given by
 .Fl f Ar file .

--- a/src/bin/poudriere-bulk.8
+++ b/src/bin/poudriere-bulk.8
@@ -128,8 +128,9 @@ of the binary package branch to use to prefetch packages.
 Should be
 .Qq latest ,
 .Qq quarterly ,
+.Qq release_* ,
 or
-.Qq release_* .
+.Ar url .
 With this option poudriere will first try to fetch from the binary package
 repository specified the binary package prior to do the sanity check if the
 package does not already exist.

--- a/src/bin/poudriere-bulk.8
+++ b/src/bin/poudriere-bulk.8
@@ -28,7 +28,7 @@
 .\"
 .\" Note: The date here should be updated whenever a non-trivial
 .\" change is made to the manual page.
-.Dd April 26, 2021
+.Dd May 6, 2021
 .Dt POUDRIERE-BULK 8
 .Os
 .Sh NAME
@@ -126,6 +126,13 @@ or
 With this option poudriere will first try to fetch from the binary package
 repository specified the binary package prior to do the sanity check if the
 package does not already exist.
+When
+.Fl t
+is used along with
+.Fl C ,
+or
+.Fl c ,
+then listed packages will not be fetched.
 .It Fl B Ar name
 Specify which buildname to use.
 By default

--- a/src/bin/poudriere-testport.8
+++ b/src/bin/poudriere-testport.8
@@ -69,8 +69,9 @@ of the binary package branch to use to prefetch packages.
 Should be
 .Qq latest ,
 .Qq quarterly ,
+.Qq release_* ,
 or
-.Qq release_* .
+.Ar url .
 With this option poudriere will first try to fetch from the binary package
 repository specified the binary package prior to do the sanity check if the
 package does not already exist.

--- a/src/bin/poudriere-testport.8
+++ b/src/bin/poudriere-testport.8
@@ -28,7 +28,7 @@
 .\"
 .\" Note: The date here should be updated whenever a non-trivial
 .\" change is made to the manual page.
-.Dd April 26, 2021
+.Dd May 6, 2021
 .Dt POUDRIERE-TESTPORT 8
 .Os
 .Sh NAME
@@ -62,6 +62,19 @@ By default
 will be used.
 This can be used to resume a previous build and use the same log and URL paths.
 Resuming a build will not retry built/failed/skipped/ignored packages.
+.It Fl b Ar name
+Specify the
+.Ar name
+of the binary package branch to use to prefetch packages.
+Should be
+.Qq latest ,
+.Qq quarterly ,
+or
+.Qq release_* .
+With this option poudriere will first try to fetch from the binary package
+repository specified the binary package prior to do the sanity check if the
+package does not already exist.
+The port being tested will not be fetched.
 .It Fl c
 Run make config for the given port.
 .It Fl I

--- a/src/bin/poudriere-testport.8
+++ b/src/bin/poudriere-testport.8
@@ -76,6 +76,13 @@ With this option poudriere will first try to fetch from the binary package
 repository specified the binary package prior to do the sanity check if the
 package does not already exist.
 The port being tested will not be fetched.
+.Pp
+See
+.Sy PACKAGE_FETCH_BRANCH ,
+and
+.Sy PACKAGE_FETCH_URL ,
+in
+.Pa poudriere.conf.sample .
 .It Fl c
 Run make config for the given port.
 .It Fl I

--- a/src/etc/poudriere.conf.sample
+++ b/src/etc/poudriere.conf.sample
@@ -330,4 +330,5 @@ DISTFILES_CACHE=/usr/ports/distfiles
 # XXX: This is subject to change
 # Default: off; requires -b <branch> for bulk or testport.
 #PACKAGE_FETCH_BRANCH=latest
+# The branch will be appended to the URL:
 #PACKAGE_FETCH_URL=pkg+http://pkg.FreeBSD.org/\${ABI}

--- a/src/etc/poudriere.conf.sample
+++ b/src/etc/poudriere.conf.sample
@@ -325,3 +325,9 @@ DISTFILES_CACHE=/usr/ports/distfiles
 # Set to pass arguments to buildworld.
 # Default:
 #MAKEWORLDARGS="WITHOUT_LLVM_ASSERTIONS=yes WITH_MALLOC_PRODUCTION=yes -DMALLOC_PRODUCTION"
+
+# Set to always attempt to fetch packages or dependencies before building.
+# XXX: This is subject to change
+# Default: off; requires -b <branch> for bulk or testport.
+#PACKAGE_FETCH_BRANCH=latest
+#PACKAGE_FETCH_URL=pkg+http://pkg.FreeBSD.org/\${ABI}

--- a/src/share/poudriere/bulk.sh
+++ b/src/share/poudriere/bulk.sh
@@ -38,6 +38,8 @@ Options:
     -B name     -- What buildname to use (must be unique, defaults to
                    YYYY-MM-DD_HH:MM:SS). Resuming a previous build will not
                    retry built/failed/skipped/ignored packages.
+    -b branch   -- Branch to chose for fetching packages from official
+                   repositories: valid options are: latest, quarterly
     -C          -- Clean only the packages listed on the command line or
                    -f file.  Implies -c for -a.
     -c          -- Clean all the previously built binary packages and logs.
@@ -92,13 +94,21 @@ OVERLAYS=""
 
 [ $# -eq 0 ] && usage
 
-while getopts "aB:CcFf:iIj:J:knNO:p:RrSTtvwz:" FLAG; do
+while getopts "ab:B:CcFf:iIj:J:knNO:p:RrSTtvwz:" FLAG; do
 	case "${FLAG}" in
 		a)
 			ALL=1
 			;;
 		B)
 			BUILDNAME="${OPTARG}"
+			;;
+		b)
+			PACKAGE_BRANCH="${OPTARG}"
+			case "${PACKAGE_BRANCH}" in
+			latest|quarterly) ;;
+			*)
+				err 1 "Invalid branch name for packages: ${OPTARG}"
+			esac
 			;;
 		c)
 			CLEAN=1

--- a/src/share/poudriere/bulk.sh
+++ b/src/share/poudriere/bulk.sh
@@ -39,7 +39,7 @@ Options:
                    YYYY-MM-DD_HH:MM:SS). Resuming a previous build will not
                    retry built/failed/skipped/ignored packages.
     -b branch   -- Branch to choose for fetching packages from official
-                   repositories: valid options are: latest, quarterly
+                   repositories: valid options are: latest, quarterly, release_*
     -C          -- Clean only the packages listed on the command line or
                    -f file.  Implies -c for -a.
     -c          -- Clean all the previously built binary packages and logs.
@@ -105,7 +105,7 @@ while getopts "ab:B:CcFf:iIj:J:knNO:p:RrSTtvwz:" FLAG; do
 		b)
 			PACKAGE_BRANCH="${OPTARG}"
 			case "${PACKAGE_BRANCH}" in
-			latest|quarterly) ;;
+			latest|quarterly|release*) ;;
 			*)
 				err 1 "Invalid branch name for packages: ${OPTARG}"
 			esac

--- a/src/share/poudriere/bulk.sh
+++ b/src/share/poudriere/bulk.sh
@@ -104,11 +104,7 @@ while getopts "ab:B:CcFf:iIj:J:knNO:p:RrSTtvwz:" FLAG; do
 			;;
 		b)
 			PACKAGE_BRANCH="${OPTARG}"
-			case "${PACKAGE_BRANCH}" in
-			latest|quarterly|release*) ;;
-			*)
-				err 1 "Invalid branch name for packages: ${OPTARG}"
-			esac
+			validate_package_branch "${PACKAGE_BRANCH}"
 			;;
 		c)
 			CLEAN=1

--- a/src/share/poudriere/bulk.sh
+++ b/src/share/poudriere/bulk.sh
@@ -38,7 +38,7 @@ Options:
     -B name     -- What buildname to use (must be unique, defaults to
                    YYYY-MM-DD_HH:MM:SS). Resuming a previous build will not
                    retry built/failed/skipped/ignored packages.
-    -b branch   -- Branch to chose for fetching packages from official
+    -b branch   -- Branch to choose for fetching packages from official
                    repositories: valid options are: latest, quarterly
     -C          -- Clean only the packages listed on the command line or
                    -f file.  Implies -c for -a.

--- a/src/share/poudriere/bulk.sh
+++ b/src/share/poudriere/bulk.sh
@@ -39,7 +39,8 @@ Options:
                    YYYY-MM-DD_HH:MM:SS). Resuming a previous build will not
                    retry built/failed/skipped/ignored packages.
     -b branch   -- Branch to choose for fetching packages from official
-                   repositories: valid options are: latest, quarterly, release_*
+                   repositories: valid options are: latest, quarterly,
+                   release_*, or a url.
     -C          -- Clean only the packages listed on the command line or
                    -f file.  Implies -c for -a.
     -c          -- Clean all the previously built binary packages and logs.

--- a/src/share/poudriere/bulk.sh
+++ b/src/share/poudriere/bulk.sh
@@ -103,8 +103,8 @@ while getopts "ab:B:CcFf:iIj:J:knNO:p:RrSTtvwz:" FLAG; do
 			BUILDNAME="${OPTARG}"
 			;;
 		b)
-			PACKAGE_BRANCH="${OPTARG}"
-			validate_package_branch "${PACKAGE_BRANCH}"
+			PACKAGE_FETCH_BRANCH="${OPTARG}"
+			validate_package_branch "${PACKAGE_FETCH_BRANCH}"
 			;;
 		c)
 			CLEAN=1

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2987,11 +2987,11 @@ jail_cleanup() {
 
 download_from_repo() {
 	msg "Prefetching missing packages from pkg+http://pkg.freebsd.org/\${ABI}/${PACKAGE_BRANCH}"
-	cat >> ${MASTERMNT}/etc/pkg/poudriere.conf <<EOF
-FreeBSD: {
-        url: pkg+http://pkg.freebsd.org/\${ABI}/${PACKAGE_BRANCH};
-}
-EOF
+	cat >> "${MASTERMNT}/etc/pkg/poudriere.conf" <<-EOF
+	FreeBSD: {
+	        url: pkg+http://pkg.freebsd.org/\${ABI}/${PACKAGE_BRANCH};
+	}
+	EOF
 	umount ${UMOUNT_NONBUSY} ${MASTERMNT}/packages || \
 	    umount -f ${MASTERMNT}/packages
 	mount_packages
@@ -2999,12 +2999,14 @@ EOF
 	# XXX only work when PKG_EXT is the same as the upstream
 	(
 	while mapfile_read_loop "all_pkgs" pkgname originspec _ignored; do
-		[ -f ${MASTERMNT}/packages/All/${pkgname}.${PKG_EXT} ] || echo ${pkgname}
+		[ -f "${MASTERMNT}/packages/All/${pkgname}.${PKG_EXT}" ] || \
+		    echo "${pkgname}"
 	done
-	)| JNETNAME="n" injail xargs env -i ASSUME_ALWAYS_YES=yes pkg fetch -o /packages
+	) | JNETNAME="n" injail xargs \
+	    env -i ASSUME_ALWAYS_YES=yes pkg fetch -o /packages
 	# Remount ro
-	umount ${UMOUNT_NONBUSY} ${MASTERMNT}/packages || \
-	    umount -f ${MASTERMNT}/packages
+	umount ${UMOUNT_NONBUSY} "${MASTERMNT}/packages" || \
+	    umount -f "${MASTERMNT}/packages"
 	mount_packages -o ro
 }
 
@@ -7728,8 +7730,8 @@ clean_restricted() {
 	bset status "clean_restricted:"
 	# Remount rw
 	# mount_nullfs does not support mount -u
-	umount ${UMOUNT_NONBUSY} ${MASTERMNT}/packages || \
-	    umount -f ${MASTERMNT}/packages
+	umount ${UMOUNT_NONBUSY} "${MASTERMNT}/packages" || \
+	    umount -f "${MASTERMNT}/packages"
 	mount_packages
 	injail /usr/bin/make -s -C ${PORTSDIR} -j ${PARALLEL_JOBS} \
 	    RM="/bin/rm -fv" ECHO_MSG="true" clean-restricted
@@ -7739,8 +7741,8 @@ clean_restricted() {
 		    RM="/bin/rm -fv" ECHO_MSG="true" clean-restricted
 	done
 	# Remount ro
-	umount ${UMOUNT_NONBUSY} ${MASTERMNT}/packages || \
-	    umount -f ${MASTERMNT}/packages
+	umount ${UMOUNT_NONBUSY} "${MASTERMNT}/packages" || \
+	    umount -f "${MASTERMNT}/packages"
 	mount_packages -o ro
 }
 

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -3009,6 +3009,10 @@ download_from_repo() {
 	        url: ${packagesite};
 	}
 	EOF
+	if [ "${DRY_RUN:-0}" -eq 1 ]; then
+		msg "not fetching remote packages in dry run mode."
+		return
+	fi
 	remount_packages -o rw
 	# only list packages which do not exists to prevent pkg from overwriting prebuilt packages
 	# XXX only work when PKG_EXT is the same as the upstream

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2986,6 +2986,9 @@ jail_cleanup() {
 }
 
 download_from_repo() {
+	[ "${PWD}" = "${MASTERMNT}/.p" ] || \
+	    err 1 "download_from_repo requires PWD=${MASTERMNT}/.p"
+
 	msg "Prefetching missing packages from pkg+http://pkg.freebsd.org/\${ABI}/${PACKAGE_BRANCH}"
 	cat >> "${MASTERMNT}/etc/pkg/poudriere.conf" <<-EOF
 	FreeBSD: {

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -7507,7 +7507,7 @@ prepare_ports() {
 		fi
 	fi
 
-	if [ -n "${PACKAGE_BRANCH}" ]; then
+	if [ -n "${PACKAGE_BRANCH-}" ]; then
 		download_from_repo
 	fi
 

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2994,7 +2994,7 @@ jail_cleanup() {
 download_from_repo() {
 	[ "${PWD}" = "${MASTERMNT}/.p" ] || \
 	    err 1 "download_from_repo requires PWD=${MASTERMNT}/.p"
-	local pkgname originspec _ignored pkg_bin pkgname packagesite
+	local pkgname originspec listed pkg_bin pkgname packagesite
 
 	if ensure_pkg_installed; then
 		pkg_bin="${PKG_BIN}"
@@ -3022,7 +3022,16 @@ download_from_repo() {
 		# only list packages which do not exists to prevent pkg
 		# from overwriting prebuilt packages
 		# XXX only work when PKG_EXT is the same as the upstream
-		while mapfile_read_loop "all_pkgs" pkgname originspec _ignored; do
+		while mapfile_read_loop "all_pkgs" pkgname originspec listed; do
+			# Skip listed packages when testing
+			if [ "${PORTTESTING}" -eq 1 ]; then
+				if [ "${CLEAN:-0}" -eq 1 ] || \
+				    [ "${CLEAN_LISTED:-0}" -eq 1 ]; then
+					case "${listed}" in
+					listed) continue ;;
+					esac
+				fi
+			fi
 			[ -f "${PACKAGES}/All/${pkgname}.${PKG_EXT}" ] || \
 			    echo "${pkgname}"
 		done

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2988,6 +2988,7 @@ jail_cleanup() {
 download_from_repo() {
 	[ "${PWD}" = "${MASTERMNT}/.p" ] || \
 	    err 1 "download_from_repo requires PWD=${MASTERMNT}/.p"
+	local pkgname originspec _ignored
 
 	if ! ensure_pkg_installed; then
 		msg "pkg package missing, skipping fetching of packages"

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -3009,12 +3009,10 @@ download_from_repo() {
 	remount_packages -o rw
 	# only list packages which do not exists to prevent pkg from overwriting prebuilt packages
 	# XXX only work when PKG_EXT is the same as the upstream
-	(
 	while mapfile_read_loop "all_pkgs" pkgname originspec _ignored; do
 		[ -f "${MASTERMNT}/packages/All/${pkgname}.${PKG_EXT}" ] || \
 		    echo "${pkgname}"
-	done
-	) | JNETNAME="n" injail xargs \
+	done | JNETNAME="n" injail xargs \
 	    env -i ASSUME_ALWAYS_YES=yes pkg fetch -o /packages
 	remount_packages -o ro
 }

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -3051,6 +3051,17 @@ download_from_repo() {
 	    err 1 "download_from_repo: failed to bootstrap pkg"
 }
 
+validate_package_branch() {
+	[ $# -eq 1 ] || eargs validate_package_branch PACKAGE_BRANCH
+	local PACKAGE_BRANCH="$1"
+
+	case "${PACKAGE_BRANCH}" in
+	latest|quarterly|release*) ;;
+	*)
+		err 1 "Invalid branch name for package fetching: ${PACKAGE_BRANCH}"
+	esac
+}
+
 # return 0 if the package dir exists and has packages, 0 otherwise
 package_dir_exists_and_has_packages() {
 	[ ! -d ${PACKAGES}/All ] && return 1

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2989,6 +2989,10 @@ download_from_repo() {
 	[ "${PWD}" = "${MASTERMNT}/.p" ] || \
 	    err 1 "download_from_repo requires PWD=${MASTERMNT}/.p"
 
+	if ! ensure_pkg_installed; then
+		msg "pkg package missing, skipping fetching of packages"
+		return
+	fi
 	msg "Prefetching missing packages from pkg+http://pkg.freebsd.org/\${ABI}/${PACKAGE_BRANCH}"
 	cat >> "${MASTERMNT}/etc/pkg/poudriere.conf" <<-EOF
 	FreeBSD: {

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -3002,7 +3002,7 @@ download_from_repo() {
 		# Will bootstrap
 		pkg_bin="pkg"
 	fi
-	packagesite="pkg+http://pkg.freebsd.org/\${ABI}/${PACKAGE_BRANCH}"
+	packagesite="${PACKAGE_FETCH_URL}/${PACKAGE_FETCH_BRANCH}"
 	msg "Prefetching missing packages from ${packagesite}"
 	cat >> "${MASTERMNT}/etc/pkg/poudriere.conf" <<-EOF
 	FreeBSD: {
@@ -3052,13 +3052,13 @@ download_from_repo() {
 }
 
 validate_package_branch() {
-	[ $# -eq 1 ] || eargs validate_package_branch PACKAGE_BRANCH
-	local PACKAGE_BRANCH="$1"
+	[ $# -eq 1 ] || eargs validate_package_branch PACKAGE_FETCH_BRANCH
+	local PACKAGE_FETCH_BRANCH="$1"
 
-	case "${PACKAGE_BRANCH}" in
+	case "${PACKAGE_FETCH_BRANCH}" in
 	latest|quarterly|release*) ;;
 	*)
-		err 1 "Invalid branch name for package fetching: ${PACKAGE_BRANCH}"
+		err 1 "Invalid branch name for package fetching: ${PACKAGE_FETCH_BRANCH}"
 	esac
 }
 
@@ -7505,7 +7505,7 @@ prepare_ports() {
 			:> ${log}/.poudriere.ports.skipped
 			trim_ignored
 		fi
-		if [ -n "${PACKAGE_BRANCH-}" ]; then
+		if [ -n "${PACKAGE_FETCH_BRANCH-}" ]; then
 			download_from_repo
 		fi
 	fi
@@ -8319,6 +8319,7 @@ INTERACTIVE_MODE=0
 : ${ALLOW_MAKE_JOBS_PACKAGES=pkg ccache}
 : ${FLAVOR_DEFAULT_ALL:=no}
 : ${NULLFS_PATHS:="/rescue /usr/share /usr/tests /usr/lib32"}
+: ${PACKAGE_FETCH_URL:="pkg+http://pkg.FreeBSD.org/\${ABI}"}
 
 : ${POUDRIERE_TMPDIR:=$(command mktemp -dt poudriere)}
 : ${SHASH_VAR_PATH_DEFAULT:=${POUDRIERE_TMPDIR}}

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -3002,7 +3002,7 @@ download_from_repo() {
 		# Will bootstrap
 		pkg_bin="pkg"
 	fi
-	packagesite="${PACKAGE_FETCH_URL}/${PACKAGE_FETCH_BRANCH}"
+	packagesite="${PACKAGE_FETCH_URL:+${PACKAGE_FETCH_URL}/}${PACKAGE_FETCH_BRANCH}"
 	msg "Prefetching missing packages from ${packagesite}"
 	cat >> "${MASTERMNT}/etc/pkg/poudriere.conf" <<-EOF
 	FreeBSD: {
@@ -3057,6 +3057,9 @@ validate_package_branch() {
 
 	case "${PACKAGE_FETCH_BRANCH}" in
 	latest|quarterly|release*) ;;
+	*:*)
+		unset PACKAGE_FETCH_URL
+		;;
 	*)
 		err 1 "Invalid branch name for package fetching: ${PACKAGE_FETCH_BRANCH}"
 	esac

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -3015,7 +3015,7 @@ download_from_repo() {
 		[ -f "${MASTERMNT}/packages/All/${pkgname}.${PKG_EXT}" ] || \
 		    echo "${pkgname}"
 	done | JNETNAME="n" injail xargs \
-	    env -i ASSUME_ALWAYS_YES=yes ${pkg_bin} fetch -o /packages
+	    env ASSUME_ALWAYS_YES=yes ${pkg_bin} fetch -o /packages
 	# Ensure pkg has a proper symlink
 	remount_packages -o ro
 	# Bootstrapped.  Need to setup symlinks.

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -7505,10 +7505,9 @@ prepare_ports() {
 			:> ${log}/.poudriere.ports.skipped
 			trim_ignored
 		fi
-	fi
-
-	if [ -n "${PACKAGE_BRANCH-}" ]; then
-		download_from_repo
+		if [ -n "${PACKAGE_BRANCH-}" ]; then
+			download_from_repo
+		fi
 	fi
 
 	if ! ensure_pkg_installed && [ ${SKIPSANITY} -eq 0 ]; then

--- a/src/share/poudriere/testport.sh
+++ b/src/share/poudriere/testport.sh
@@ -83,8 +83,8 @@ OVERLAYS=""
 while getopts "b:B:o:cniIj:J:kNO:p:PSvwz:" FLAG; do
 	case "${FLAG}" in
 		b)
-			PACKAGE_BRANCH="${OPTARG}"
-			validate_package_branch "${PACKAGE_BRANCH}"
+			PACKAGE_FETCH_BRANCH="${OPTARG}"
+			validate_package_branch "${PACKAGE_FETCH_BRANCH}"
 			;;
 		B)
 			BUILDNAME="${OPTARG}"

--- a/src/share/poudriere/testport.sh
+++ b/src/share/poudriere/testport.sh
@@ -39,7 +39,8 @@ Options:
                    YYYY-MM-DD_HH:MM:SS). Resuming a previous build will not
                    retry built/failed/skipped/ignored packages.
     -b branch   -- Branch to choose for fetching packages from official
-                   repositories: valid options are: latest, quarterly, release_*
+                   repositories: valid options are: latest, quarterly,
+                   release_*, or a url.
     -c          -- Run make config for the given port
     -i          -- Interactive mode. Enter jail for interactive testing and
                    automatically cleanup when done.

--- a/src/share/poudriere/testport.sh
+++ b/src/share/poudriere/testport.sh
@@ -38,6 +38,8 @@ Options:
     -B name     -- What buildname to use (must be unique, defaults to
                    YYYY-MM-DD_HH:MM:SS). Resuming a previous build will not
                    retry built/failed/skipped/ignored packages.
+    -b branch   -- Branch to choose for fetching packages from official
+                   repositories: valid options are: latest, quarterly, release_*
     -c          -- Run make config for the given port
     -i          -- Interactive mode. Enter jail for interactive testing and
                    automatically cleanup when done.
@@ -78,8 +80,12 @@ PTNAME="default"
 BUILD_REPO=1
 OVERLAYS=""
 
-while getopts "B:o:cniIj:J:kNO:p:PSvwz:" FLAG; do
+while getopts "b:B:o:cniIj:J:kNO:p:PSvwz:" FLAG; do
 	case "${FLAG}" in
+		b)
+			PACKAGE_BRANCH="${OPTARG}"
+			validate_package_branch "${PACKAGE_BRANCH}"
+			;;
 		B)
 			BUILDNAME="${OPTARG}"
 			;;


### PR DESCRIPTION
As soon as we have the entire list of packages to build but before
the sanity check, pre fetch all the binary packages that we can
from the official repositories.

The sanity check running after than will probably destroy some
packages for which the confiration will be different or any reason
suitable for the sanity check to destroy packages.

When listing the packages to fetch only list the one not already
existing to avoid pkg fetch to redownload and overwrite packages
we have already customized