### PR TITLE
setup_xdev: only set AS if as(1) is present

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2322,7 +2322,6 @@ setup_xdev() {
 	CC=/nxb-bin/usr/bin/cc
 	CPP=/nxb-bin/usr/bin/cpp
 	CXX=/nxb-bin/usr/bin/c++
-	AS=/nxb-bin/usr/bin/as
 	NM=/nxb-bin/usr/bin/nm
 	LD=/nxb-bin/usr/bin/ld
 	OBJCOPY=/nxb-bin/usr/bin/objcopy
@@ -2336,6 +2335,14 @@ setup_xdev() {
 	AWK=/nxb-bin/usr/bin/awk
 	FLEX=/nxb-bin/usr/bin/flex
 	EOF
+
+	# as(1) has been removed in FreeBSD 13.0.  Just check if it's present
+	# in the target environment's /nxb-bin and use it if it's there.
+	if [ -f "${mnt}/nxb-bin/usr/bin/as" ]; then
+		cat >> "${mnt}/etc/make.nxb.conf" <<-EOF
+		AS=/nxb-bin/usr/bin/as
+		EOF
+	fi
 
 	# hardlink these files to capture scripts and tools
 	# that explicitly call them instead of using paths.


### PR DESCRIPTION
Notably, as(1) has been removed from base in advance of FreeBSD 13. All
ports that require it now have a build dependency on it. We could just
remove this entirely and force it to use binutils on FreeBSD 11 and 12, but
this is more consistent with how these dependencies are setup for native
builds.

This fixes the build of lang/ocaml, and likely others, on -CURRENT
cross-builds with native-xtools.

Signed-off-by: Kyle Evans <kevans@FreeBSD.org>