### PR TITLE
set the canonical FreeBSD base repo

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -7851,7 +7851,7 @@ if [ -z "${NO_ZFS}" ]; then
 fi
 
 : ${SVN_HOST="svn.freebsd.org"}
-: ${GIT_BASEURL="github.com/freebsd/freebsd.git"}
+: ${GIT_BASEURL="git.freebsd.org/src.git"}
 : ${GIT_PORTSURL="github.com/freebsd/freebsd-ports.git"}
 : ${FREEBSD_HOST="https://download.FreeBSD.org"}
 if [ -z "${NO_ZFS}" ]; then


### PR DESCRIPTION
since the migration of base to git, we should use that as the canonical git repo