### PR TITLE
Don't hardcode many properties and try to inherit as much as possible

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -1430,9 +1430,11 @@ get_data_dir() {
 		# Set properties on top dataset and let underlying ones inherit them
 		# Explicitly set properties for values diverging from top dataset
 		zfs create -p -o atime=off \
-			-o compression=lz4 \ 
+			-o compression=on \ 
 			-o mountpoint=${BASEFS} \
 			${ZPOOL}${ZROOTFS}
+		zfs create ${ZPOOL}${ZROOTFS}/jails
+		zfs create ${ZPOOL}${ZROOTFS}/ports
 		zfs create -o ${NS}:type=data ${ZPOOL}${ZROOTFS}/data
 		zfs create ${ZPOOL}${ZROOTFS}/data/.m
 		zfs create -o compression=off ${ZPOOL}${ZROOTFS}/data/cache

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -1427,14 +1427,17 @@ get_data_dir() {
 			zfs get -H -o value mountpoint ${ZPOOL}${ZROOTFS}/data
 			return
 		fi
-		zfs create -p -o ${NS}:type=data \
-			-o atime=off \
-			-o mountpoint=${BASEFS}/data \
-			${ZPOOL}${ZROOTFS}/data
+		# Set properties on top dataset and let underlying ones inherit them
+		# Explicitly set properties for values diverging from top dataset
+		zfs create -p -o atime=off \
+			-o compression=lz4 \ 
+			-o mountpoint=${BASEFS} \
+			${ZPOOL}${ZROOTFS}
+		zfs create -o ${NS}:type=data ${ZPOOL}${ZROOTFS}/data
 		zfs create ${ZPOOL}${ZROOTFS}/data/.m
 		zfs create -o compression=off ${ZPOOL}${ZROOTFS}/data/cache
-		zfs create -o compression=on ${ZPOOL}${ZROOTFS}/data/images
-		zfs create -o compression=lz4 ${ZPOOL}${ZROOTFS}/data/logs
+		zfs create ${ZPOOL}${ZROOTFS}/data/images
+		zfs create ${ZPOOL}${ZROOTFS}/data/logs
 		zfs create -o compression=off ${ZPOOL}${ZROOTFS}/data/packages
 		zfs create -o compression=off ${ZPOOL}${ZROOTFS}/data/wrkdirs
 	else

--- a/src/share/poudriere/include/fs.sh
+++ b/src/share/poudriere/include/fs.sh
@@ -34,7 +34,7 @@ createfs() {
 
 	if [ -n "${fs}" -a "${fs}" != "none" ]; then
 		msg_n "Creating ${name} fs at ${mnt}..."
-		if ! zfs create -p ${fs}; then
+		if ! zfs create ${fs}; then
 			echo " fail"
 			err 1 "Failed to create FS ${fs}"
 		fi

--- a/src/share/poudriere/include/fs.sh
+++ b/src/share/poudriere/include/fs.sh
@@ -34,7 +34,7 @@ createfs() {
 
 	if [ -n "${fs}" -a "${fs}" != "none" ]; then
 		msg_n "Creating ${name} fs at ${mnt}..."
-		if ! zfs create ${fs}; then
+		if ! zfs create -p ${fs}; then
 			echo " fail"
 			err 1 "Failed to create FS ${fs}"
 		fi

--- a/src/share/poudriere/include/fs.sh
+++ b/src/share/poudriere/include/fs.sh
@@ -34,10 +34,7 @@ createfs() {
 
 	if [ -n "${fs}" -a "${fs}" != "none" ]; then
 		msg_n "Creating ${name} fs at ${mnt}..."
-		if ! zfs create -p \
-			-o compression=lz4 \
-			-o atime=off \
-			-o mountpoint=${mnt} ${fs}; then
+		if ! zfs create ${fs}; then
 			echo " fail"
 			err 1 "Failed to create FS ${fs}"
 		fi


### PR DESCRIPTION
This should fix issue #794.

I just need to get some insight if the createfs is used for anything else besides creating jails or port trees. As the mountpoint is not needed for ZFS it will just be inherited from the top dataset. Not sure if I'm missing something.