### PR TITLE
Fix git checkout during jail update to operate within SRC_BASE.

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -639,7 +639,7 @@ install_from_vcs() {
 		git*)
 			${GIT_CMD} -C ${SRC_BASE} pull --rebase -q || err 1 " fail"
 			if [ -n "${TORELEASE}" ]; then
-				${GIT_CMD} checkout -q "${TORELEASE}" || err 1 " fail"
+				${GIT_CMD} -C ${SRC_BASE} checkout -q "${TORELEASE}" || err 1 " fail"
 			fi
 			echo " done"
 			;;


### PR DESCRIPTION
The `git checkout` command during the jail update is missing the `-C ${SRC_BASE}` flag to make it operate inside the git directory. This leads to this error:

```
$ sudo poudriere jail -u -j current -t 2333220ae1a71ce51429b9d206a765df0562c987
[00:00:00] Upgrading using git+https
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```