### PR TITLE
quote $KERNEL not only when checked, also when used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ src/poudriere-sh/builtins.h
 src/poudriere-sh/shell.h
 external/ptsort/.git
 external/ptsort/.gitignore
+test/prep

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -412,7 +412,7 @@ installworld() {
 	if [ -n "${KERNEL}" ]; then
 		msg "Starting make installkernel"
 		${MAKE_CMD} -C "${SRC_BASE}" ${make_jobs} installkernel \
-		    KERNCONF=${KERNEL} DESTDIR=${destdir} ${MAKEWORLDARGS} || \
+		    KERNCONF="${KERNEL}" DESTDIR=${destdir} ${MAKEWORLDARGS} || \
 		    err 1 "Failed to 'make installkernel'"
 	fi
 
@@ -508,7 +508,7 @@ buildworld() {
 	if [ -n "${KERNEL}" ]; then
 		msg "Starting make buildkernel with ${PARALLEL_JOBS} jobs"
 		${MAKE_CMD} -C ${SRC_BASE} buildkernel ${MAKE_JOBS} \
-			KERNCONF=${KERNEL} ${MAKEWORLDARGS} || \
+			KERNCONF="${KERNEL}" ${MAKEWORLDARGS} || \
 			err 1 "Failed to 'make buildkernel'"
 	fi
 }
@@ -952,7 +952,7 @@ create_jail() {
 	jset ${JAILNAME} arch ${ARCH}
 	jset ${JAILNAME} mnt ${JAILMNT}
 	[ -n "$SRCPATH" ] && jset ${JAILNAME} srcpath ${SRCPATH}
-	[ -n "${KERNEL}" ] && jset ${JAILNAME} kernel ${KERNEL}
+	[ -n "${KERNEL}" ] && jset ${JAILNAME} kernel "${KERNEL}"
 
 	# Wrap the jail creation in a special cleanup hook that will remove the jail
 	# if any error is encountered
@@ -1137,7 +1137,7 @@ while getopts "bBiJ:j:v:a:z:m:nf:M:sdkK:lqcip:r:uU:t:z:P:S:DxC:" FLAG; do
 			STOP=1
 			;;
 		K)
-			KERNEL=${OPTARG:-GENERIC}
+			KERNEL="${OPTARG:-GENERIC}"
 			;;
 		l)
 			LIST=1

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -217,7 +217,7 @@ update_pkgbase() {
 	fi
 
 	msg "Starting make update-packages"
-	${MAKE_CMD} -C "${SRC_BASE}" ${make_jobs} update-packages \
+	${MAKE_CMD} -C "${SRC_BASE}" ${make_jobs} update-packages KERNCONF="${KERNEL}" \
 	    DESTDIR="${destdir}" REPODIR="${POUDRIERE_DATA}/images/${JAILNAME}-repo" ${MAKEWORLDARGS}
 	case $? in
 	    0)
@@ -225,7 +225,7 @@ update_pkgbase() {
 		return
 		;;
 	    2)
-		${MAKE_CMD} -C "${SRC_BASE}" ${make_jobs} packages \
+		${MAKE_CMD} -C "${SRC_BASE}" ${make_jobs} packages KERNCONF="${KERNEL}" \
 		    DESTDIR="${destdir}" REPODIR="${POUDRIERE_DATA}/images/${JAILNAME}-repo" ${MAKEWORLDARGS} || \
 		    err 1 "Failed to 'make packages'"
 		run_hook jail pkgbase "${POUDRIERE_DATA}/images/${JAILNAME}-repo"
@@ -428,7 +428,7 @@ build_pkgbase() {
 	fi
 
 	msg "Starting make packages"
-	${MAKE_CMD} -C "${SRC_BASE}" ${make_jobs} packages \
+	${MAKE_CMD} -C "${SRC_BASE}" ${make_jobs} packages KERNCONF="${KERNEL}" \
 	    DESTDIR=${destdir} REPODIR=${POUDRIERE_DATA}/images/${JAILNAME}-repo ${MAKEWORLDARGS} || \
 		err 1 "Failed to 'make packages'"
 


### PR DESCRIPTION
since -K kernel could be a list, we should quote it when we use it, not
only when checking if it's set.

This pull request fixes part of #818, namely the build error in poudriere.