### PR TITLE
add PKG_REPO_SIGNING_KEY to make (update-)packages invocation

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -217,17 +217,23 @@ update_pkgbase() {
 	fi
 
 	msg "Starting make update-packages"
-	${MAKE_CMD} -C "${SRC_BASE}" ${make_jobs} update-packages KERNCONF="${KERNEL}" \
-	    DESTDIR="${destdir}" REPODIR="${POUDRIERE_DATA}/images/${JAILNAME}-repo" ${MAKEWORLDARGS}
+	env ${PKG_REPO_SIGNING_KEY:+PKG_REPO_SIGNING_KEY="${PKG_REPO_SIGNING_KEY}"} \
+		${MAKE_CMD} -C "${SRC_BASE}" ${make_jobs} update-packages \
+			KERNCONF="${KERNEL}" DESTDIR="${destdir}" \
+			REPODIR="${POUDRIERE_DATA}/images/${JAILNAME}-repo" \
+			${MAKEWORLDARGS}
 	case $? in
 	    0)
 		run_hook jail pkgbase "${POUDRIERE_DATA}/images/${JAILNAME}-repo"
 		return
 		;;
 	    2)
-		${MAKE_CMD} -C "${SRC_BASE}" ${make_jobs} packages KERNCONF="${KERNEL}" \
-		    DESTDIR="${destdir}" REPODIR="${POUDRIERE_DATA}/images/${JAILNAME}-repo" ${MAKEWORLDARGS} || \
-		    err 1 "Failed to 'make packages'"
+		env ${PKG_REPO_SIGNING_KEY:+PKG_REPO_SIGNING_KEY="${PKG_REPO_SIGNING_KEY}"} \
+			${MAKE_CMD} -C "${SRC_BASE}" ${make_jobs} packages \
+				KERNCONF="${KERNEL}" DESTDIR="${destdir}" \
+				REPODIR="${POUDRIERE_DATA}/images/${JAILNAME}-repo"
+				${MAKEWORLDARGS} || \
+			err 1 "Failed to 'make packages'"
 		run_hook jail pkgbase "${POUDRIERE_DATA}/images/${JAILNAME}-repo"
 		;;
 	    *)
@@ -428,8 +434,11 @@ build_pkgbase() {
 	fi
 
 	msg "Starting make packages"
-	${MAKE_CMD} -C "${SRC_BASE}" ${make_jobs} packages KERNCONF="${KERNEL}" \
-	    DESTDIR=${destdir} REPODIR=${POUDRIERE_DATA}/images/${JAILNAME}-repo ${MAKEWORLDARGS} || \
+	env ${PKG_REPO_SIGNING_KEY:+PKG_REPO_SIGNING_KEY="${PKG_REPO_SIGNING_KEY}"} \
+		${MAKE_CMD} -C "${SRC_BASE}" ${make_jobs} packages \
+			KERNCONF="${KERNEL}" DESTDIR=${destdir} \
+			REPODIR=${POUDRIERE_DATA}/images/${JAILNAME}-repo
+			${MAKEWORLDARGS} || \
 		err 1 "Failed to 'make packages'"
 
 	run_hook jail pkgbase "${POUDRIERE_DATA}/images/${JAILNAME}-repo"


### PR DESCRIPTION
during a pkgbase build, if PKG_REPO_SIGNING_KEY is set, we ensure it's set  during package building

This addresses #812.