### PR TITLE
(partially?) un-hardcode txz

### DIFF
--- a/src/etc/poudriere.conf.sample
+++ b/src/etc/poudriere.conf.sample
@@ -176,7 +176,7 @@ DISTFILES_CACHE=/usr/ports/distfiles
 # If set, failed builds will save the WRKDIR to ${POUDRIERE_DATA}/wrkdirs
 # SAVE_WRKDIR=yes
 
-# Choose the default format for the workdir packing: could be tar,tgz,tbz,txz
+# Choose the default format for the workdir packing: could be tar,tgz,tbz,txz,tzst
 # default is tbz
 # WRKDIR_ARCHIVE_FORMAT=tbz
 

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2178,7 +2178,7 @@ commit_packages() {
 		[ ! -L "${PACKAGES_ROOT}/${name}" ] || continue
 		if [ -e "${PACKAGES_ROOT}/${name}" ]; then
 			case "${name}" in
-			.buildname|.jailversion|meta.txz|digests.txz|packagesite.txz|All|Latest)
+			.buildname|.jailversion|meta.${PKG_EXT}|digests.${PKG_EXT}|packagesite.${PKG_EXT}|All|Latest)
 				# Auto fix pkg-owned files
 				unlink "${PACKAGES_ROOT:?}/${name}"
 				;;
@@ -7875,7 +7875,7 @@ prepare_ports() {
 	if [ $SKIPSANITY -eq 0 ]; then
 		msg "Sanity checking the repository"
 
-		for n in repo.txz digests.txz packagesite.txz; do
+		for n in repo.${PKG_EXT} digests.${PKG_EXT} packagesite.${PKG_EXT}; do
 			pkg="${PACKAGES}/All/${n}"
 			if [ -f "${pkg}" ]; then
 				msg "Removing invalid pkg repo file: ${pkg}"
@@ -8177,10 +8177,13 @@ build_repo() {
 	    err 1 "Unable to extract pkg."
 	run_hook pkgrepo sign "${PACKAGES}" "${PKG_REPO_SIGNING_KEY}" \
 	    "${PKG_REPO_FROM_HOST:-no}" "${PKG_REPO_META_FILE}"
+	PKG_META="-m /tmp/pkgmeta"
+	PKG_META_MASTERMNT="-m ${MASTERMNT}/tmp/pkgmeta"
 	if [ -r "${PKG_REPO_META_FILE:-/nonexistent}" ]; then
-		PKG_META="-m /tmp/pkgmeta"
-		PKG_META_MASTERMNT="-m ${MASTERMNT}/tmp/pkgmeta"
 		install -m 0400 "${PKG_REPO_META_FILE}" \
+		    ${MASTERMNT}/tmp/pkgmeta
+	else
+		printf "version = 2;\npacking_format = \"${PKG_EXT}\";\n" > \
 		    ${MASTERMNT}/tmp/pkgmeta
 	fi
 	mkdir -p ${MASTERMNT}/tmp/packages

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -7875,7 +7875,7 @@ prepare_ports() {
 	if [ $SKIPSANITY -eq 0 ]; then
 		msg "Sanity checking the repository"
 
-		for n in repo.{pkg,txz} digests.{pkg,txz} packagesite.{pkg,txz}; do
+		for n in repo.pkg repo.txz digests.pkg digests.txz packagesite.pkg packagesite.txz; do
 			pkg="${PACKAGES}/All/${n}"
 			if [ -f "${pkg}" ]; then
 				msg "Removing invalid pkg repo file: ${pkg}"

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -3948,6 +3948,7 @@ save_wrkdir() {
 	tgz) COMPRESSKEY="z" ;;
 	tbz) COMPRESSKEY="j" ;;
 	txz) COMPRESSKEY="J" ;;
+	tzst) COMPRESSKEY="-zstd" ;;
 	esac
 	unlink ${tarname}
 
@@ -3955,7 +3956,7 @@ save_wrkdir() {
 	    WRKDIR wrkdir || \
 	    err 1 "Failed to lookup WRKDIR for ${originspec}"
 
-	tar -s ",${mnt}${wrkdir%/*},," -c${COMPRESSKEY}f "${tarname}" \
+	tar -s ",${mnt}${wrkdir%/*},," -cf "${tarname}" -${COMPRESSKEY} \
 	    "${mnt}${wrkdir}" > /dev/null 2>&1
 
 	job_msg "Saved ${COLOR_PORT}${originspec} | ${pkgname}${COLOR_RESET} wrkdir to: ${tarname}"
@@ -8507,7 +8508,7 @@ if [ -e "${POUDRIERE_DATA}" ]; then
 fi
 : ${WRKDIR_ARCHIVE_FORMAT="tbz"}
 case "${WRKDIR_ARCHIVE_FORMAT}" in
-	tar|tgz|tbz|txz);;
+	tar|tgz|tbz|txz|tzst);;
 	*) err 1 "invalid format for WRKDIR_ARCHIVE_FORMAT: ${WRKDIR_ARCHIVE_FORMAT}" ;;
 esac
 

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -3956,7 +3956,7 @@ save_wrkdir() {
 	    WRKDIR wrkdir || \
 	    err 1 "Failed to lookup WRKDIR for ${originspec}"
 
-	tar -s ",${mnt}${wrkdir%/*},," -cf "${tarname}" ${COMPRESSKEY:-${COMPRESSKEY}} \
+	tar -s ",${mnt}${wrkdir%/*},," -cf "${tarname}" ${COMPRESSKEY:+-${COMPRESSKEY}} \
 	    "${mnt}${wrkdir}" > /dev/null 2>&1
 
 	job_msg "Saved ${COLOR_PORT}${originspec} | ${pkgname}${COLOR_RESET} wrkdir to: ${tarname}"

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2178,7 +2178,7 @@ commit_packages() {
 		[ ! -L "${PACKAGES_ROOT}/${name}" ] || continue
 		if [ -e "${PACKAGES_ROOT}/${name}" ]; then
 			case "${name}" in
-			.buildname|.jailversion|meta.pkg|meta.${PKG_COMPRESSION_FORMAT}|digests.pkg|digests.${PKG_COMPRESSION_FORMAT}|packagesite.pkg|packagesite.${PKG_COMPRESSION_FORMAT}|All|Latest)
+			.buildname|.jailversion|meta.pkg|meta.txz|digests.pkg|digests.txz|packagesite.pkg|packagesite.txz|All|Latest)
 				# Auto fix pkg-owned files
 				unlink "${PACKAGES_ROOT:?}/${name}"
 				;;
@@ -7875,7 +7875,7 @@ prepare_ports() {
 	if [ $SKIPSANITY -eq 0 ]; then
 		msg "Sanity checking the repository"
 
-		for n in repo.{pkg,${PKG_COMPRESSION_FORMAT}} digests.{pkg,${PKG_COMPRESSION_FORMAT}} packagesite.{pkg,${PKG_COMPRESSION_FORMAT}}; do
+		for n in repo.{pkg,txz} digests.{pkg,txz} packagesite.{pkg,txz}; do
 			pkg="${PACKAGES}/All/${n}"
 			if [ -f "${pkg}" ]; then
 				msg "Removing invalid pkg repo file: ${pkg}"

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -3956,7 +3956,7 @@ save_wrkdir() {
 	    WRKDIR wrkdir || \
 	    err 1 "Failed to lookup WRKDIR for ${originspec}"
 
-	tar -s ",${mnt}${wrkdir%/*},," -cf "${tarname}" -${COMPRESSKEY} \
+	tar -s ",${mnt}${wrkdir%/*},," -cf "${tarname}" ${COMPRESSKEY:-${COMPRESSKEY}} \
 	    "${mnt}${wrkdir}" > /dev/null 2>&1
 
 	job_msg "Saved ${COLOR_PORT}${originspec} | ${pkgname}${COLOR_RESET} wrkdir to: ${tarname}"

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -8177,13 +8177,10 @@ build_repo() {
 	    err 1 "Unable to extract pkg."
 	run_hook pkgrepo sign "${PACKAGES}" "${PKG_REPO_SIGNING_KEY}" \
 	    "${PKG_REPO_FROM_HOST:-no}" "${PKG_REPO_META_FILE}"
-	PKG_META="-m /tmp/pkgmeta"
-	PKG_META_MASTERMNT="-m ${MASTERMNT}/tmp/pkgmeta"
 	if [ -r "${PKG_REPO_META_FILE:-/nonexistent}" ]; then
+		PKG_META="-m /tmp/pkgmeta"
+		PKG_META_MASTERMNT="-m ${MASTERMNT}/tmp/pkgmeta"
 		install -m 0400 "${PKG_REPO_META_FILE}" \
-		    ${MASTERMNT}/tmp/pkgmeta
-	else
-		printf "packing_format = \"${PKG_COMPRESSION_FORMAT}\";\n" > \
 		    ${MASTERMNT}/tmp/pkgmeta
 	fi
 	mkdir -p ${MASTERMNT}/tmp/packages

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2178,7 +2178,7 @@ commit_packages() {
 		[ ! -L "${PACKAGES_ROOT}/${name}" ] || continue
 		if [ -e "${PACKAGES_ROOT}/${name}" ]; then
 			case "${name}" in
-			.buildname|.jailversion|meta.${PKG_EXT}|digests.${PKG_EXT}|packagesite.${PKG_EXT}|All|Latest)
+			.buildname|.jailversion|meta.${PKG_COMPRESSION_FORMAT}|digests.${PKG_COMPRESSION_FORMAT}|packagesite.${PKG_COMPRESSION_FORMAT}|All|Latest)
 				# Auto fix pkg-owned files
 				unlink "${PACKAGES_ROOT:?}/${name}"
 				;;
@@ -7875,7 +7875,7 @@ prepare_ports() {
 	if [ $SKIPSANITY -eq 0 ]; then
 		msg "Sanity checking the repository"
 
-		for n in repo.${PKG_EXT} digests.${PKG_EXT} packagesite.${PKG_EXT}; do
+		for n in repo.${PKG_COMPRESSION_FORMAT} digests.${PKG_COMPRESSION_FORMAT} packagesite.${PKG_COMPRESSION_FORMAT}; do
 			pkg="${PACKAGES}/All/${n}"
 			if [ -f "${pkg}" ]; then
 				msg "Removing invalid pkg repo file: ${pkg}"
@@ -8183,7 +8183,7 @@ build_repo() {
 		install -m 0400 "${PKG_REPO_META_FILE}" \
 		    ${MASTERMNT}/tmp/pkgmeta
 	else
-		printf "version = 2;\npacking_format = \"${PKG_EXT}\";\n" > \
+		printf "packing_format = \"${PKG_COMPRESSION_FORMAT}\";\n" > \
 		    ${MASTERMNT}/tmp/pkgmeta
 	fi
 	mkdir -p ${MASTERMNT}/tmp/packages

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2178,7 +2178,7 @@ commit_packages() {
 		[ ! -L "${PACKAGES_ROOT}/${name}" ] || continue
 		if [ -e "${PACKAGES_ROOT}/${name}" ]; then
 			case "${name}" in
-			.buildname|.jailversion|meta.${PKG_COMPRESSION_FORMAT}|digests.${PKG_COMPRESSION_FORMAT}|packagesite.${PKG_COMPRESSION_FORMAT}|All|Latest)
+			.buildname|.jailversion|meta.pkg|meta.${PKG_COMPRESSION_FORMAT}|digests.pkg|digests.${PKG_COMPRESSION_FORMAT}|packagesite.pkg|packagesite.${PKG_COMPRESSION_FORMAT}|All|Latest)
 				# Auto fix pkg-owned files
 				unlink "${PACKAGES_ROOT:?}/${name}"
 				;;
@@ -7875,7 +7875,7 @@ prepare_ports() {
 	if [ $SKIPSANITY -eq 0 ]; then
 		msg "Sanity checking the repository"
 
-		for n in repo.${PKG_COMPRESSION_FORMAT} digests.${PKG_COMPRESSION_FORMAT} packagesite.${PKG_COMPRESSION_FORMAT}; do
+		for n in repo.{pkg,${PKG_COMPRESSION_FORMAT}} digests.{pkg,${PKG_COMPRESSION_FORMAT}} packagesite.{pkg,${PKG_COMPRESSION_FORMAT}}; do
 			pkg="${PACKAGES}/All/${n}"
 			if [ -f "${pkg}" ]; then
 				msg "Removing invalid pkg repo file: ${pkg}"


### PR DESCRIPTION
Commits are self-explanatory.

Successfully generated repos with zstd-compressed packages. Should allow `PKG_NOCOMPRESS` to work to fix #459 (although not tested on my end).