### PR TITLE
git+ssh: the git URL based on ssh starts with git@

### DIFF
--- a/src/share/poudriere/ports.sh
+++ b/src/share/poudriere/ports.sh
@@ -153,7 +153,7 @@ if [ -n "${SOURCES_URL}" ]; then
 		;;
 	git*)
 		case "${SOURCES_URL}" in
-		ssh://*) METHOD="git+ssh" ;;
+		git@*) METHOD="git+ssh" ;;
 		http://*) METHOD="git+http" ;;
 		https://*) METHOD="git+https" ;;
 		git://*) METHOD="git" ;;

--- a/src/share/poudriere/ports.sh
+++ b/src/share/poudriere/ports.sh
@@ -154,6 +154,7 @@ if [ -n "${SOURCES_URL}" ]; then
 	git*)
 		case "${SOURCES_URL}" in
 		git@*) METHOD="git+ssh" ;;
+		ssh://*) METHOD="git+ssh" ;;
 		http://*) METHOD="git+http" ;;
 		https://*) METHOD="git+https" ;;
 		git://*) METHOD="git" ;;

--- a/src/share/poudriere/ports.sh
+++ b/src/share/poudriere/ports.sh
@@ -153,12 +153,13 @@ if [ -n "${SOURCES_URL}" ]; then
 		;;
 	git*)
 		case "${SOURCES_URL}" in
-		git@*) METHOD="git+ssh" ;;
 		ssh://*) METHOD="git+ssh" ;;
 		http://*) METHOD="git+http" ;;
 		https://*) METHOD="git+https" ;;
 		git://*) METHOD="git" ;;
 		file:///*) METHOD="git" ;;
+		*://*) err 1 "Invalid git protocol" ;;
+		*:*) METHOD="git+ssh" ;;
 		*) err 1 "Invalid git url" ;;
 		esac
 		;;


### PR DESCRIPTION
`ssh` access to git repository is not using URL based on `ssh://` but with `git@github.com:name/repo` or `git@gitlab.com:name/repo`


This is true for github and gitlab.
This is needed to support git private repositories.