### PR TITLE
Don't allow /dev/bpf* in jails

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -1664,7 +1664,7 @@ do_jail_mounts() {
 	local from="$1"
 	local mnt="$2"
 	local name="$3"
-	local devfspath="null zero random urandom stdin stdout stderr fd fd/* bpf* pts pts/*"
+	local devfspath="null zero random urandom stdin stdout stderr fd fd/* pts pts/*"
 	local srcpath nullpaths nullpath p arch
 
 	# from==mnt is via jail -u


### PR DESCRIPTION
net/libnet10 which bpf device was enabled for was removed from the ports tree, net/libnet does not need this and I've just fixed net/libdnet.
If any port ever needs this, the port must be fixed instead - ports must never need to access bpf during the build.

This effectively reverts e3a299603ece5b27da22284d58e2dd6afead30c05