### PR TITLE
Prepare older installs to take advantage of inheritance

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -1414,6 +1414,13 @@ get_data_dir() {
 	fi
 
 	if [ -z "${NO_ZFS}" ]; then
+		# Prepare older installs to take advantage of inheritance
+		zrootfsmountpoint=$(zfs get -o value -H mountpoint ${ZPOOL}${ZROOTFS})
+		if [ "${zrootfsmountpoint}" != ${BASEFS} ]; then
+			zfs inherit -r mountpoint ${ZPOOL}${ZROOTFS}
+			zfs set mountpoint=${BASEFS} ${ZPOOL}${ZROOTFS}
+		fi
+		# Normal place to look for the data mountpoint
 		data=$(zfs list -rt filesystem -H -o ${NS}:type,mountpoint ${ZPOOL}${ZROOTFS} 2>/dev/null |
 		    awk '$1 == "data" { print $2; exit; }')
 		if [ -n "${data}" ]; then

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -1415,7 +1415,7 @@ get_data_dir() {
 
 	if [ -z "${NO_ZFS}" ]; then
 		# Prepare older installs to take advantage of inheritance
-		zrootfsmountpoint=$(zfs get -o value -H mountpoint ${ZPOOL}${ZROOTFS})
+		zrootfsmountpoint=$(zfs get -H -o value mountpoint ${ZPOOL}${ZROOTFS})
 		if [ "${zrootfsmountpoint}" != ${BASEFS} ]; then
 			zfs inherit -r mountpoint ${ZPOOL}${ZROOTFS}
 			zfs set mountpoint=${BASEFS} ${ZPOOL}${ZROOTFS}


### PR DESCRIPTION
With new way of ZFS dataset creation, going from an explicit mountpoint to an inherited mountpoint there was a problem with existing dataset structures not having the correct mountpoint assigned resulting in a failed jail or port tree creation. This fixes #844.