### PR TITLE
jail: unbreak git checkout of a local clone

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -1254,8 +1254,8 @@ if [ -n "${SOURCES_URL}" ]; then
 		ssh://*) METHOD="git+ssh" ;;
 		http://*) METHOD="git+http" ;;
 		https://*) METHOD="git+https" ;;
+		file://*) METHOD="git+file" ;;
 		git://*) METHOD="git" ;;
-		file://*) METHOD="git" ;;
 		*) err 1 "Invalid git url" ;;
 		esac
 		;;
@@ -1275,6 +1275,7 @@ else
 	git+ssh) proto="ssh" ;;
 	git+http) proto="http" ;;
 	git+https) proto="https" ;;
+	git+file) proto="file" ;;
 	git) proto="git" ;;
 	esac
 	SVN_FULLURL=${proto}://${SVN_HOST}/base


### PR DESCRIPTION
```
$ fgrep GIT /usr/local/etc/poudriere.conf
GIT_BASEURL=/path/to/freebsd-src

$ git clone https://git.freebsd.org/src.git /path/to/freebsd-src
$ poudriere jail -cj main-amd64 -a amd64 -v main -m git+file
[00:00:00] Creating main-amd64 fs at /poudriere/jails/main-amd64... done
[00:00:00] Checking out the sources with git+file...fatal: protocol '' is not supported
[00:00:00] Error:  fail
[00:00:00] Error while creating jail, cleaning up.
[00:00:00] Removing main-amd64 jail... done
[00:00:00] Cleaning main-amd64 data... done
```