### PR TITLE
change Makefile identification for logfiles

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -844,7 +844,7 @@ buildlog_start() {
 	echo "package name: ${pkgname}"
 	echo "building for: $(injail uname -a)"
 	echo "maintained by: ${mk_MAINTAINER}"
-	echo "Makefile ident: $(ident -q ${mnt}/${portdir}/Makefile|sed -n '2,2p')"
+	echo "Makefile datestamp: $(ls -l ${mnt}/${portdir}/Makefile)"
 	echo "Poudriere version: ${POUDRIERE_VERSION}"
 	echo "Host OSVERSION: ${HOST_OSVERSION}"
 	echo "Jail OSVERSION: ${JAIL_OSVERSION}"


### PR DESCRIPTION
With the switch to git, the logfile line starting with "Makefile ident" has become useless (ident(1) returns empty, as expected).

To help people figure out which version of the port was run, switch it out for an ls -l of the Makefile itself.