### PR TITLE
Fix firmware images

### DIFF
--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -161,7 +161,7 @@ get_uefi_bootname() {
 }
 
 make_esp_file() {
-    local file sizekb loader device stagedir fatbits efibootname
+    local file size loader device stagedir fatbits efibootname
 
     msg "Creating ESP image"
     file=$1


### PR DESCRIPTION
I will close #847 in favor of this PR. There's still room for improvement, but with these minimal changes, firmware images can be successfully built.

It accounts for the ESP in firmware images, and also fixes a few nits. It also incorporates 1f7c18bdc12fc48f80fd3f55c2250d766c035e6d, but for `image_firmware.sh`.

### Test

Build the image according to:

https://bsdrp.net/documentation/technical_docs/poudriere#the_6_minimum_steps_to_build_a_poudriere_firmware_image

7. Test the image using bhyve:

       # sh /usr/share/examples/bhyve/vmrun.sh -u -t tap0 -d /usr/local/poudriere/data/images/router.img router

   and with EFI:

       # sh /usr/share/examples/bhyve/vmrun.sh -uE -t tap0 -d /usr/local/poudriere/data/images/router.img router
