### PR TITLE
image: Remove traces of embedded image type

### DIFF
--- a/completions/bash/poudriere
+++ b/completions/bash/poudriere
@@ -238,7 +238,7 @@ _poudriere()
                         _poudriere_ports_list
                         ;;
                     -t)
-                        COMPREPLY=($(compgen -W 'iso iso+mfs iso+zmfs usb usb+mfs usb+zmfs rawdisk zrawdisk tar firmware rawfirmware embedded' -- "$cur"))
+                        COMPREPLY=($(compgen -W 'iso iso+mfs iso+zmfs usb usb+mfs usb+zmfs rawdisk zrawdisk tar firmware rawfirmware' -- "$cur"))
                         ;;
                     -z)
                         _poudriere_set_list

--- a/completions/zsh/_poudriere
+++ b/completions/zsh/_poudriere
@@ -59,7 +59,7 @@ _image=(
 	'-o[image destination directory]:directory:_files'
 	'-p[Ports tree]::tree:_poudriere_pt'
 	'-s[set the image size]:size:'
-	'-t[type of image]::type:((iso iso+mfs iso+zmfs usb usb+mfs usb+zmfs rawdisk zrawdisk tar firmware rawfirmware embedded))'
+	'-t[type of image]::type:((iso iso+mfs iso+zmfs usb usb+mfs usb+zmfs rawdisk zrawdisk tar firmware rawfirmware))'
 	'-X[file containing the list in cpdup format]:file:_files'
 	'-z[set]::'
 )

--- a/src/man/poudriere-image.8
+++ b/src/man/poudriere-image.8
@@ -125,8 +125,6 @@ An XZ-compressed tarball.
 A NanoBSD style image with a GPT partitions and a UEFI boot loader.
 .It rawfirmware
 A raw disk image.
-.It embedded
-Create a u-boot ready embedded image.
 .It zsnapshot
 Create a zfs snapshot full and incremental to be used in a jail.
 .El


### PR DESCRIPTION
This was somehow missed in 88d6ff2bfc2424887bfb142cf6e7da1302cb32a9.