### PR TITLE
Add new configuration variable BUILD_JAIL_SILENTLY

### DIFF
--- a/src/etc/poudriere.conf.sample
+++ b/src/etc/poudriere.conf.sample
@@ -322,6 +322,12 @@ DISTFILES_CACHE=/usr/ports/distfiles
 # Default: no
 #HTML_TRACK_REMAINING=yes
 
+# Display less messages when building/installing/updating jail from
+# source tree, Affect only when you use either '-b' or '-m git|svn.'
+# option of `jail` command,
+# Default: no
+# BUILD_JAIL_SILENTLY=yes
+
 # Set to pass arguments to buildworld.
 # Default:
 #MAKEWORLDARGS="WITHOUT_LLVM_ASSERTIONS=yes WITH_MALLOC_PRODUCTION=yes -DMALLOC_PRODUCTION"

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -418,6 +418,9 @@ setup_build_env() {
 			err 1 "You need fmake installed on the host: devel/fmake"
 		MAKE_CMD=${FMAKE}
 	fi
+	if [ "${BUILD_JAIL_SILENTLY}" = "yes" ]; then
+		MAKE_CMD="${MAKE_CMD} -s"
+	fi
 
 	: ${CCACHE_BIN:="/usr/local/libexec/ccache"}
 	if [ -n "${CCACHE_DIR}" -a -d ${CCACHE_BIN}/world ]; then


### PR DESCRIPTION
Add new configuration variable `BUILD_JAIL_SILENTLY`. If you set it to `yes` in poudriere.conf, then `-s` option is passed to make(1) and therefore less messages are displayed when building/installing/updating jail from source tree. It affects only when you use either `-b` or `-m git|svn` option of `jail` command.