### PR TITLE
Allow to specify base mount point for jails using JAIL_BASEMNT

### DIFF
--- a/src/etc/poudriere.conf.sample
+++ b/src/etc/poudriere.conf.sample
@@ -336,6 +336,10 @@ DISTFILES_CACHE=/usr/ports/distfiles
 # you have local patches for as otherwise the patches would be ignored if
 # a remote package is used instead.
 #PACKAGE_FETCH_BLACKLIST=""
+# Alternatively a whitelist can be created to only allow specific packages to
+# be fetched.
+# Default: everything
+#PACKAGE_FETCH_WHITELIST="gcc* rust llvm*"
 
 # Set the base mount point for jails
 # Default:

--- a/src/etc/poudriere.conf.sample
+++ b/src/etc/poudriere.conf.sample
@@ -336,3 +336,7 @@ DISTFILES_CACHE=/usr/ports/distfiles
 # you have local patches for as otherwise the patches would be ignored if
 # a remote package is used instead.
 #PACKAGE_FETCH_BLACKLIST=""
+
+# Set the base mount point for jails
+# Default:
+#JAIL_BASEMNT=${POUDRIERE_DATA}/.m

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -283,7 +283,7 @@ _mastermnt() {
 	mastername="${MASTERNAME}"
 	_gsub_badchars "${mastername}" ":" mastername
 	mnt="${JAIL_BASEMNT}/${mastername}/ref"
-	if [ -z "${NOLINUX}" ]; then
+	if [ -z "${NOLINUX-}" ]; then
 		testpath="/compat/linux/proc"
 	else
 		testpath="/var/db/ports"

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -148,7 +148,7 @@ delete_jail() {
 	fi
 	cache_dir="${POUDRIERE_DATA}/cache/${JAILNAME}-*"
 	rm -rfx ${POUDRIERED}/jails/${JAILNAME} ${cache_dir} \
-		${POUDRIERE_DATA}/.m/${JAILNAME}-* || :
+		${JAIL_BASEMNT}/${JAILNAME}-* || :
 	echo " done"
 	if [ "${CLEANJAIL}" = "none" ]; then
 		return 0


### PR DESCRIPTION
It is sometimes desirable (for example, when poudriere data is on NFS, as in my case) to have base jail mount on local filesystem to avoid unnecessary NFS traffic.

This patch adds `JAIL_BASEMNT` variable that can override the default `${POUDRIERE_DATA}/.m`
