### PR TITLE
Address feedback in ensure_pkg_installed()

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -5119,11 +5119,11 @@ ensure_pkg_installed() {
 	    [ -f /usr/local/sbin/pkg-static ]; then
 		for pkg_ext in ${PKG_EXT} txz; do
 			[ -r "${MASTERMNT}/packages/Latest/pkg.${pkg_ext}" ] || continue
-			injail_ver=$( realpath "${MASTERMNT}/packages/Latest/pkg.${pkg_ext}" )
+			injail_ver=$(realpath "${MASTERMNT}/packages/Latest/pkg.${pkg_ext}")
 			injail_ver=${injail_ver##*/}
 			injail_ver=${injail_ver##*-}
 			injail_ver=${injail_ver%.*}
-			host_ver=$( /usr/local/sbin/pkg-static -v )
+			host_ver=$(/usr/local/sbin/pkg-static -v)
 			if [ "${host_ver}" = "${injail_ver}" ]; then
 				cp -f /usr/local/sbin/pkg-static "${mnt}/.p/pkg-static"
 			return 0

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -5116,12 +5116,19 @@ ensure_pkg_installed() {
 	[ -z "${force}" ] && [ -x "${mnt}${PKG_BIN}" ] && return 0
 	# Hack, speed up QEMU usage on pkg-repo.
 	if [ ${QEMU_EMULATING} -eq 1 ] && \
-	    [ -f /usr/local/sbin/pkg-static ] && \
-	    for pkg_ext in ${PKG_EXT} txz; do [ -r "${MASTERMNT}/packages/Latest/pkg.${pkg_ext}" ] || continue && injail_ver=$( basename `realpath "${MASTERMNT}/packages/Latest/pkg.${pkg_ext}"` | sed -e 's/pkg-//' -e "s/\.${pkg_ext}//" -e 's/\.pkg//' ); done && \
-	    host_ver=$( /usr/local/sbin/pkg-static -v ) && \
-	    [ ${host_ver} = ${injail_ver} ]; then
-		cp -f /usr/local/sbin/pkg-static "${mnt}/.p/pkg-static"
-		return 0
+	    [ -f /usr/local/sbin/pkg-static ]; then
+		for pkg_ext in ${PKG_EXT} txz; do
+			[ -r "${MASTERMNT}/packages/Latest/pkg.${pkg_ext}" ] || continue
+			injail_ver=$( realpath "${MASTERMNT}/packages/Latest/pkg.${pkg_ext}" )
+			injail_ver=${injail_ver##*/}
+			injail_ver=${injail_ver##*-}
+			injail_ver=${injail_ver%.*}
+			host_ver=$( /usr/local/sbin/pkg-static -v )
+			if [ "${host_ver}" = "${injail_ver}" ]; then
+				cp -f /usr/local/sbin/pkg-static "${mnt}/.p/pkg-static"
+			return 0
+			fi
+		done
 	fi
 	for pkg_ext in ${PKG_EXT} txz; do
 		[ -r "${MASTERMNT}/packages/Latest/pkg.${pkg_ext}" ] || \

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -5126,7 +5126,7 @@ ensure_pkg_installed() {
 			host_ver=$(/usr/local/sbin/pkg-static -v)
 			if [ "${host_ver}" = "${injail_ver}" ]; then
 				cp -f /usr/local/sbin/pkg-static "${mnt}/.p/pkg-static"
-			return 0
+				return 0
 			fi
 		done
 	fi


### PR DESCRIPTION
@bdrewery wrote:
> Thanks for fixing.
> 
> * `foo || <something> && <something>` is not a safe construct.
> 
> ```
> # sh -c 'false || echo continue && echo injail_ver'
> continue
> injail_ver
> # sh -c 'if ! false; then echo continue; else echo injail_ver; fi'
> continue
> # sh -c 'true || echo continue && echo injail_ver'
> injail_ver
> ```
> 
> While `continue` would avoid the `injail_ver` code the pattern is prone to error and surprises since its scope is ambiguous. More examples:
> 
> ```
> # true && { echo "in &&"; false; } || echo "in ||"
> in &&
> in ||
> # true && false || echo "in ||"
> in ||
> # false || true && echo "in &&"
> in &&

I agree, it is easy to miss what is happening.

> ```
> 
>  * We don't need `sed` or `basename`
> 
> ```
> # cat blah
> #!/bin/sh
> PACKAGES=/poudriere/data/packages/exp-12amd64-commit-test
> injail_ver=$(realpath "${PACKAGES}/Latest/pkg.pkg")
>                                            # globs
> injail_ver=${injail_ver##*/} # trim beginning */ = pkgbase-pkgversion.ext
> injail_ver=${injail_ver##*-} # trim beginning *- = pkgversion.ext
> injail_ver=${injail_ver%.*}   # trim end .*      = pkgversion
> echo $injail_ver
> # sh blah
> 1.17.0
> ```

Oh yeah, I always forget about sh(1) substring processing.

>  * We duplicate the search for pkg.txz/pkg.pkg now.
> * The line length and style are not correct or consistent
>   `$()` can be nested
> 
> ```
> # echo 0$(echo 1$(echo hi))
> 01hi
> ```

I had actually done this on purpose to make it easier to differentiate between them, but that preference is probably not universal.  Re: line length I was trying to prevent the nesting from getting too deep, but now seeing how it actually looks in this new version I was worried for nothing.  What do you think?

>  * `[ ${host_ver} = ${injail_ver} ]` will cause a syntax error (crash) if either `host_ver` or `injail_ver` is empty but not the other.
> 
> ```
> # [ ${host_ver} = ${injail_ver} ]
> # host_ver=1
> # [ ${host_ver} = ${injail_ver} ]
> [: =: argument expected
> ```
> 
> Quotes, and the character hack, avoids this
> 
> ```
> # host_ver=1
> # [ "${host_ver}" = "${injail_ver}" ]
> # [ s${host_ver} = s${injail_ver} ]
> #
> ```

Yeah, good point. I probably, incorrectly, assume that they would never be empty.


How does this look?