### PR TITLE
Update httpd.conf.sample

### DIFF
--- a/src/share/examples/poudriere/httpd.conf.sample
+++ b/src/share/examples/poudriere/httpd.conf.sample
@@ -3,6 +3,6 @@ Alias /poudriere/data "/usr/local/poudriere/data/logs/bulk"
 Alias /poudriere "/usr/local/share/poudriere/html"
 
 <Location /poudriere>
-        Allow from all
         Options Indexes
+        Require all granted
 </Location>


### PR DESCRIPTION
"Allow from all" is used in apache 2.2 , while there is only apache 2.4 in FreeBSD portstree.