### PR TITLE
Allow poudreire.d/ports to be a symlink.

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -1569,8 +1569,8 @@ jail_runs() {
 porttree_list() {
 	local name method p
 
-	[ -d ${POUDRIERED}/ports ] || return 0
-	for p in $(find ${POUDRIERED}/ports -type d -maxdepth 1 -mindepth 1 -print); do
+	[ -d ${POUDRIERED}/ports ] || [ -L ${POUDRIERED}/ports ] || return 0
+	for p in $(find ${POUDRIERED}/ports/ -type d -maxdepth 1 -mindepth 1 -print); do
 		name=${p##*/}
 		_pget mnt ${name} mnt || :
 		_pget method ${name} method || :


### PR DESCRIPTION
When maintaining a large number of configurations, it may be helpful to
split out each configuration into it's own poudreire.d, and symlink into
a shared ports and jail directory.