### PR TITLE
image: Allow prebuild script to replace the built-in _prepare

### DIFF
--- a/src/man/poudriere-image.8
+++ b/src/man/poudriere-image.8
@@ -62,8 +62,9 @@ partition to be grown to fill the remaining space on a disk.
 .It Fl B Ar pre-script
 Source the
 .Ar pre-script
-file instead of using the default methods to create the image file, add
-partitions, format filesystems, and then mount them to
+file before the image prepare function.
+Can optionally replace the prepare function, in which case it should create the
+image file, add partitions, format filesystems, and then mount them to
 .Ev $WRKDIR Ns
 /world before the contents are installed to that directory.
 .Pp
@@ -144,6 +145,12 @@ The size of the image file to be created, in bytes.
 The name of the image (from
 .Fl n Ar name Ns
 ).
+.It Ev SKIP_PREPARE
+If set, do not run the image types default prepare function.
+The pre-script must then create the image file, add partitions,
+format filesystems, and then mount them to
+.Ev $WRKDIR Ns
+/world .
 .It Ev WORLDDIR
 The path to the directory that is the root of the image.
 .It Ev zroot

--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -424,8 +424,6 @@ boot/kernel.old
 nxb-bin
 EOF
 
-${MAINMEDIATYPE}_prepare ${SUBMEDIATYPE} || err 1 "${MAINMEDIATYPE}_prepare failed"
-
 # Need to convert IMAGESIZE from bytes to bibytes
 # This conversion is needed to be compliant with marketing 'unit'
 # without this, a 2GiB image will not fit into a 2GB flash disk (=1862MiB)
@@ -491,17 +489,14 @@ if [ -n "${SWAPSIZE}" ]; then
 	SWAPSIZE="${NEW_SWAPSIZE_SIZE}${NEW_SWAPSIZE_UNIT}"
 fi
 
+SKIP_PREPARE=
 if [ -n "${PRE_BUILD_SCRIPT}" ]; then
 	. "${PRE_BUILD_SCRIPT}"
-	REAL_MEDIATYPE="${MEDIATYPE}"
-	MEDIATYPE="skip"
 fi
 
-case "${MEDIATYPE}" in
-skip)
-	MEDIATYPE="${REAL_MEDIATYPE}"
-	;;
-esac
+if [ -z "$SKIP_PREPARE" ]; then
+	${MAINMEDIATYPE}_prepare ${SUBMEDIATYPE} || err 1 "${MAINMEDIATYPE}_prepare failed"
+fi
 
 # Run the install world function
 ${INSTALLWORLD}


### PR DESCRIPTION
If the prebuild script sets SKIP_PREPARE then we don't run
${MAINMEDIATYPE}_prepare ${SUBMEDIATYPE}

Allowing users to replace the built-in _prepare for the image type

Cleans up the old 'skip' method that did nothing after b768a3692998