### PR TITLE
image: use parameter substitution to parse $MEDIATYPE

### DIFF
--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -388,8 +388,10 @@ post_getopts
 : ${IMAGENAME:=poudriereimage}
 MASTERNAME=${JAILNAME}-${PTNAME}${SETNAME:+-${SETNAME}}
 
-MAINMEDIATYPE=$(echo ${MEDIATYPE} | cut -d '+' -f 1)
-SUBMEDIATYPE=$(echo ${MEDIATYPE} | cut -d '+' -f 2)
+MAINMEDIATYPE=${MEDIATYPE%%+*}
+MEDIAREMAINDER=${MEDIATYPE#*+}
+SUBMEDIATYPE=${MEDIAREMAINDER%%+*}
+MEDIAREMAINDER=${MEDIAREMAINDER#*+}
 
 if [ "${MEDIATYPE}" = "none" ]; then
 	err 1 "Missing -t option"


### PR DESCRIPTION
Replace `$(echo ${MEDIATYPE} | cut -d '+' -f 1)` with shell builtins