### PR TITLE
poudriere.conf.sample: fix git example URLs

### DIFF
--- a/src/etc/poudriere.conf.sample
+++ b/src/etc/poudriere.conf.sample
@@ -90,13 +90,13 @@ DISTFILES_CACHE=/usr/ports/distfiles
 # mirror (default: git.FreeBSD.org/port.git)
 #
 # Example to use github mirror:
-#GIT_BASEURL=https://github.com/freebsd/freebsd-src.git
+#GIT_BASEURL=github.com/freebsd/freebsd-src.git
 
 # If set the source tree marked to use git will use the defined
 # mirror (default: git.FreeBSD.org/src.git)
 #
 # Example to use github mirror:
-#GIT_PORTSURL=https://github.com/freebsd/freebsd-ports.git
+#GIT_PORTSURL=github.com/freebsd/freebsd-ports.git
 
 # If set the ports tree or source tree marked to use svn will use the defined
 # mirror (default: svn.FreeBSD.org)


### PR DESCRIPTION
The URL should not include the schema (https://) as the protocol is
added based on the type specified when creating the jail/portstree

```
# poudriere ports -c -m git
[00:00:00] Creating default fs at /usr/local/poudriere/ports/default... done
[00:00:00] Cloning the ports tree...fatal: unable to access 'https://https://github.com/freebsd/freebsd-ports.git/': Could not resolve host: https
[00:00:00] Error:  fail
```