### PR TITLE
image_zfs: Fix inverted logic

### DIFF
--- a/src/share/poudriere/image_zfs.sh
+++ b/src/share/poudriere/image_zfs.sh
@@ -41,7 +41,7 @@ zfs_check()
 
 	[ -n "${IMAGESIZE}" ] || err 1 "Please specify the imagesize"
 	[ -n "${ZFS_POOL_NAME}" ] || err 1 "Please specify a pool name"
-	zpool list -Ho name ${ZFS_POOL_NAME} >/dev/null 2>&1 || \
+	zpool list -Ho name ${ZFS_POOL_NAME} >/dev/null 2>&1 && \
 		err 1 "Target pool name already exists"
 	case "${IMAGENAME}" in
 	''|*[!A-Za-z0-9]*)


### PR DESCRIPTION
`zpool list -Ho ${ZFS_POOL_NAME}` exits with `0` if the name exists. This prevents overwriting the existing pool.

Fixes: ae641ed4ff326fb338aff781506e4b06ead65bfc

cc/ @allanjude 