### PR TITLE
Fix thin jail creation

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -585,7 +585,7 @@ install_from_src() {
 	# Use __FreeBSD_version as our version_extra
 	setvar "${var_version_extra}" \
 	    "$(awk '/^\#define[[:blank:]]__FreeBSD_version/ {print $3}' \
-	    ${JAILMNT}/usr/include/sys/param.h)"
+	    ${JAILMNT}/usr/src/sys/sys/param.h)"
 }
 
 install_from_vcs() {
@@ -672,7 +672,7 @@ install_from_vcs() {
 	# Use __FreeBSD_version as our version_extra
 	setvar "${var_version_extra}" \
 	    "$(awk '/^\#define[[:blank:]]__FreeBSD_version/ {print $3}' \
-	    ${JAILMNT}/usr/include/sys/param.h)"
+	    ${JAILMNT}/usr/src/sys/sys/param.h)"
 }
 
 install_from_ftp() {


### PR DESCRIPTION
Some jails are very thin and do not have /usr/include/sys populated,
which leads to this error on jail creation:

awk: can't open file /usr/local/poudriere/jails/testjail/usr/include/sys/param.h
 source line number 1

So use the param.h from the src tree instead.