### PR TITLE
bash-completion: Enable filename-specific processing (like adding a slash to directory

### DIFF
--- a/completions/bash/poudriere
+++ b/completions/bash/poudriere
@@ -31,6 +31,7 @@
 # Upstream: https://github.com/0mp/poudriere-bash-completion/
 
 _poudriere_absolute_path() {
+    compopt -o filenames
     COMPREPLY=($(compgen -f "${cur:-/}" -- "$cur"))
 }
 


### PR DESCRIPTION
names, quoting special characters or suppressing trailing spaces) for
the -f switch of bulk, distclean, pkgclean and options.