### PR TITLE
testport: don't try to delete /compat/linux

### DIFF
--- a/src/share/poudriere/testport.sh
+++ b/src/share/poudriere/testport.sh
@@ -298,7 +298,7 @@ fi
 [ "${PREFIX}" != "${LOCALBASE}" ] && PORT_FLAGS="PREFIX=${PREFIX}"
 msg "Building with flags: ${PORT_FLAGS}"
 
-if [ -d ${MASTERMNT}${PREFIX} -a "${PREFIX}" != "/usr" ]; then
+if [ -d ${MASTERMNT}${PREFIX} -a "${PREFIX}" != "/usr" -a "${PREFIX}" != "/compat/linux" ]; then
 	msg "Removing existing ${PREFIX}"
 	[ "${PREFIX}" != "${LOCALBASE}" ] && rm -rf ${MASTERMNT}${PREFIX}
 fi


### PR DESCRIPTION
testport clears PREFIX before building.  When PREFIX is /compat/linux
this fails because /compat/linux/proc is mounted.  As such, exclude it
like /usr is excluded.