### PR TITLE
image: Exclude ZFS snapshot artifacts from image

### DIFF
--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -434,6 +434,7 @@ mkdir -p ${WRKDIR}/out
 WORLDDIR="${WRKDIR}/world"
 [ -z "${EXCLUDELIST}" ] || cat ${EXCLUDELIST} > ${excludelist}
 cat >> ${excludelist} << EOF
+.poudriere-snap-*
 usr/src
 var/db/freebsd-update
 var/db/etcupdate


### PR DESCRIPTION
Exclude ZFS snapshot artifacts (`.poudriere-snap-*`) from the final image.