### PR TITLE
image_zfs: Allow same-as-host pool names

### DIFF
--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -395,7 +395,7 @@ post_getopts
 : ${SWAPSIZE:=0}
 : ${PTNAME:=default}
 : ${ZFS_SEND_FLAGS:=-Rec}
-: ${ZFS_POOL_NAME:=${IMAGENAME}root}
+: ${ZFS_POOL_NAME:=zroot}
 : ${ZFS_BEROOT_NAME:=ROOT}
 : ${ZFS_BOOTFS_NAME:=default}
 
@@ -405,6 +405,8 @@ MAINMEDIATYPE=${MEDIATYPE%%+*}
 MEDIAREMAINDER=${MEDIATYPE#*+}
 SUBMEDIATYPE=${MEDIAREMAINDER%%+*}
 MEDIAREMAINDER=${MEDIAREMAINDER#*+}
+
+TMP_ZFS_POOL_NAME="${ZFS_POOL_NAME}.$(jot -r 1 1000000000)"
 
 if [ "${MEDIATYPE}" = "none" ]; then
 	err 1 "Missing -t option"


### PR DESCRIPTION
Use `zpool create -t` to set the in-core pool name to a temporary, random pool name, while the on-disk name will be the name specified as the pool name in `ZFS_POOL_NAME`, by default `zroot` to match what is currently used on release images.

Keep the check for a possible name collision on the randomly-created pool name, to err on the side of caution.

Inspired by:	https://reviews.freebsd.org/D34426

cc/ @allanjude 