### PR TITLE
Fix tmpfs blacklist wildcards

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -4717,7 +4717,7 @@ stop_builders() {
 		    [ -d "${TMPFS_BLACKLIST_TMPDIR}/wrkdirs" ]; then
 			if ! rm -rf "${TMPFS_BLACKLIST_TMPDIR}/wrkdirs/"*; then
 				chflags -R 0 \
-				    "${TMPFS_BLACKLIST_TMPDIR}/wkrdirs"/* || :
+				    "${TMPFS_BLACKLIST_TMPDIR}/wrkdirs"/* || :
 				rm -rf "${TMPFS_BLACKLIST_TMPDIR}/wrkdirs"/* ||
 				    :
 			fi

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -5151,6 +5151,11 @@ build_pkg() {
 	    err 1 "Failed to rollback ${mnt} to prepkg"
 	:> ${mnt}/.need_rollback
 
+	# Disabling globs for this loop or wildcards in
+	# TMPFS_BLACKLIST will expand to files in the
+	# current directory instead of being passed into
+	# the case statement as a pattern
+	set -o noglob
 	for jpkg in ${TMPFS_BLACKLIST-}; do
 		case "${pkgname%-*}" in
 		${jpkg})
@@ -5165,6 +5170,7 @@ build_pkg() {
 			;;
 		esac
 	done
+	set +o noglob
 
 	rm -rfx ${mnt}/wrkdirs/* || :
 


### PR DESCRIPTION
Disabling globs for the loop that checks currently
building packages against `TMPFS_BLACKLIST` or wildcards in
`TMPFS_BLACKLIST` will expand to files in the current
directory, instead of being passed into the case statement
as a pattern.

Also fixed a breaking typo in code that cleans up from `TMPFS_BLACKLIST_TMPDIR`.