### PR TITLE
Fix setting the hostname when cross building images

### DIFF
--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -532,7 +532,14 @@ pwd_mkdb -d ${WRKDIR}/world/etc -p ${WRKDIR}/world/etc/master.passwd
 
 # Set hostname
 if [ -n "${HOSTNAME}" ]; then
-	sysrc -q -R "${WRKDIR}/world" hostname="${HOSTNAME}"
+	# `sysrc -R` tries to run a shell inside the chroot(8).
+	# It may fail if the target is on a different architecture than the host.
+	# In this case, set /etc/rc.conf as the destination for the hostname.
+	if [ "${arch}" == "${host_arch}" ]; then
+		sysrc -q -R "${WRKDIR}/world" hostname="${HOSTNAME}"
+	else
+		sysrc -q -f "${WRKDIR}/world/etc/rc.conf" hostname="${HOSTNAME}"
+	fi
 fi
 
 msg "Installing packages"


### PR DESCRIPTION
Do not use `sysrc -R`, it tries to run a shell inside the chroot(8), if the files inside are built for a different architecture it fails:

    chroot: /bin/sh: Exec format error

As a workaround, work directly from the host to the /etc/rc.conf target file (`sysrc -f`).
