### PR TITLE
Handle revisions in the pkg version

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -3517,7 +3517,7 @@ _pkg_version_expanded() {
 	local -; set -f
 	[ $# -eq 1 ] || eargs pkg_ver_expanded version
 	local ver="$1"
-	local epoch ver_sub IFS
+	local epoch revision ver_sub IFS
 
 	case "${ver}" in
 	*,*)
@@ -3528,6 +3528,15 @@ _pkg_version_expanded() {
 		epoch="0"
 		;;
 	esac
+	case "${ver}" in
+	*_*)
+		revision="${ver##*_}"
+		ver="${ver%_*}"
+		;;
+	*)
+		revision="0"
+		;;
+	esac
 	_gsub "${ver}" "[_.]" " " ver_sub
 	set -- ${ver_sub}
 
@@ -3536,6 +3545,7 @@ _pkg_version_expanded() {
 		printf "%02d" "$1"
 		shift
 	done
+	printf "%04d" "${revision}"
 	printf "\n"
 }
 


### PR DESCRIPTION
If the older version of pkg has a revision and the new one does not,
the comparison function is broken.

For example, pkg version 1.17.5_1 was determined to be newer than
version 1.18.3.  This is due to how the version numbers are expanded
for comparison:

test 0001170501 -gt 00011803