### PR TITLE
New pkg do not needs devfs to be mounted when running in chroot

### DIFF
--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -542,12 +542,10 @@ if [ -n "${PACKAGELIST}" ]; then
 		FreeBSD: { enabled: false }
 		local: { url: file:///tmp/packages }
 		EOF
-		mount -t devfs devfs ${WRKDIR}/world/dev
 		convert_package_list "${PACKAGELIST}" | \
 		    xargs chroot "${WRKDIR}/world" env \
 		    REPOS_DIR=/tmp ASSUME_ALWAYS_YES=yes \
 		    pkg install
-		umount ${WRKDIR}/world/dev
 	else
 		cat > "${WRKDIR}/world/tmp/repo.conf" <<-EOF
 		FreeBSD: { enabled: false }


### PR DESCRIPTION
This was introduced in [2019](https://github.com/freebsd/poudriere/commit/5c0ca1b2960bc565176b9462a5f643664f10d1ad) when pkg open `/dev/null` after doing the chroot. In the [next release](https://github.com/freebsd/pkg/commit/5a0cc7f37e783a636e11f5499f5f8449ed318e0e) of pkg, this should not be required anymore as pkg will open `/dev/null` before doing the chroot.

Should not be merged until the new pkg is released.