### PR TITLE
jail: Add support for creating a jail from pkgbase

### DIFF
--- a/src/man/poudriere-jail.8
+++ b/src/man/poudriere-jail.8
@@ -223,6 +223,12 @@ It is expected that this directory be installed to with the following:
 It will not be copied at the time of running
 .Dq Li poudriere jail .
 Deleting the jail will attempt to revert any files changed by poudriere.
+.It Cm pkgbase= Ns Ar path
+Install from the given pkgbase repository at
+.Ar path .
+.Pp
+Note that building kernel module will not be possible as there is no
+package with the source code.
 .It Cm src= Ns Ar path
 Install from the given directory at
 .Ar path .


### PR DESCRIPTION
The full repository url will be constructed based on the arch and version arguments.
So poudriere -c -j pkgbase=http://example.com/pkgbase -a amd64 -v 14 will use the full repository present at http://example.com/pkgbase/FreeBSD:14:amd64 This might change in the futur as until we don't have official pkgbase repositories we don't know what scheme we should recommand users to use.

Both creation and update is supported.

One cavehat is that kmod can't be build as we don't have any package with the matching source code.

Sponsored by:	Beckhoff Automation GmbH & Co. KG