### PR TITLE
Allow '-f' argument to run in foreground

### DIFF
--- a/src/poudriered/poudriered.c
+++ b/src/poudriered/poudriered.c
@@ -897,6 +897,10 @@ main(int argc, char **argv)
 
 	const ucl_object_t *sock_path_o, *pidfile_path_o, *foreground_o;
 
+	if (argc == 2 && strcmp(argv[1], "-f") == 0) {
+		foreground = true;
+	}
+
 	if (argc == 3) {
 		struct ucl_parser *parser = NULL;
 


### PR DESCRIPTION
Using a config file option means that if it's set to foreground, the system will hang on startup if the RC script is enabled

If you'd prefer to use getopt(3) then I'm happy to rewrite like that.