### PR TITLE
image: regenerate pwd database to account for overlays

### DIFF
--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -524,6 +524,7 @@ if [ -f "${WRKDIR}/world/etc/login.conf.orig" ]; then
 	    "${WRKDIR}/world/etc/login.conf"
 fi
 cap_mkdb ${WRKDIR}/world/etc/login.conf
+pwd_mkdb -d ${WRKDIR}/world/etc -p ${WRKDIR}/world/etc/master.passwd
 
 # Set hostname
 if [ -n "${HOSTNAME}" ]; then


### PR DESCRIPTION
If a etc/master.passwd is specified in an overlay, regeneration of the database is required.