### PR TITLE
allow native compliation for armv6 on armv7 arch as CPU-s are backward compatible

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2644,6 +2644,9 @@ need_emulation() {
 	# kern.supported_archs is a list of TARGET_ARCHs.
 	target_arch="${wanted_arch#*.}"
 
+        # armv6 binaries can natively execute on armv7, no emulation needed
+        [ "${target_arch}" = "armv6" ] && target_arch="armv[67]"
+
 	# Check the list of supported archs from the kernel.
 	# DragonFly does not have kern.supported_archs, fallback to
 	# uname -m (advised by dillon)


### PR DESCRIPTION
poudriere asks for QEMU binary if running on armv7 host and target is armv6. As ARMv7 is backward compatible with v6 it is not realy needed. This patch relaxes this check