### PR TITLE
Fix label of time column

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -1531,7 +1531,7 @@ siginfo_handler() {
 	format_origin_phase="%%c \b%%s \b%%-%ds${COLOR_RESET} \b%%c %%-%ds ${COLOR_PORT}%%%ds %%c %%-%ds${COLOR_RESET} ${COLOR_PHASE}%%%ds${COLOR_RESET} %%-%ds %%-%ds %%%ds %%%ds"
 	display_setup "${format_origin_phase}"
 	display_add " " "" "ID" " " "TOTAL" "ORIGIN" " " "PKGNAME" "PHASE" \
-	            "PHASE" "TMPFS" "CPU%" "MEM%"
+	            "TIME" "TMPFS" "CPU%" "MEM%"
 
 	# Skip if stopping or starting jobs or stopped.
 	if [ -n "${JOBS}" -a "${status#starting_jobs:}" = "${status}" \


### PR DESCRIPTION
I've noticed that in build stats/progress output (`^T`) the time column is incorrectly labeled `PHASE`:

```
[mybuild] [2023-08-04_11h25m43s] [parallel_build:] Queued: 115 Built: 0   Failed: 0   Skipped: 0   Ignored: 0   Fetched: 7   Tobuild: 108  Time: 03:26:41
 ID  TOTAL       ORIGIN   PKGNAME     PHASE PHASE    TMPFS  CPU% MEM%
[01] 00:26:00 lang/rust | rust-1.71.0 build 00:23:52       19.9% 4.2%
```

Note how there are two columns labeled `PHASE`.
My patch fixes this by renaming the 6th column to `TIME`:

```
[mybuild] [2023-08-04_17h09m12s] [parallel_build:] Queued: 107 Built: 0   Failed: 0   Skipped: 0   Ignored: 0   Fetched: 0   Tobuild: 107  Time: 00:01:12
 ID  TOTAL          ORIGIN   PKGNAME                  PHASE TIME     TMPFS CPU% MEM%
[01] 00:00:34 devel/llvm12 | llvm12-12.0.1_10 build-depends 00:00:15         8% 0.4%
```