### PR TITLE
Add Caddyfile.sample in Makefile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,6 +48,7 @@ dist_sysconf_DATA=	\
 		src/etc/poudriere.conf.sample \
 		src/etc/poudriered.conf.sample
 dist_examples_DATA=	\
+		src/share/examples/poudriere/Caddyfile.sample \
 		src/share/examples/poudriere/nginx.conf.sample \
 		src/share/examples/poudriere/httpd.conf.sample
 


### PR DESCRIPTION
Previously I added an example for Caddy Webserver however this was not added in the Makefile.am so this patch adds the relevant example in the Makefile.am