### PR TITLE
Add option to `pkgclean` to force rebuilding the repo

### DIFF
--- a/src/man/poudriere-pkgclean.8
+++ b/src/man/poudriere-pkgclean.8
@@ -112,6 +112,8 @@ This can be used to later force rebuild anything depending on the listed
 packages.
 .It Fl R
 Also clean restricted packages.
+.It Fl u
+Force rebuilding and signing the repo, even if no change was made.
 .It Fl v
 This will show more information during the build.
 Specify twice to enable debug output.

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -579,18 +579,21 @@ stat_humanize() {
 }
 
 do_confirm_delete() {
-	[ $# -eq 4 ] || eargs do_confirm_delete badfiles_list \
-	    reason_plural_object answer DRY_RUN
+	[ $# -eq 5 ] || eargs do_confirm_delete badfiles_list \
+	    reason_plural_object answer DRY_RUN FORCE_BUILD_REPO
 	local filelist="$1"
 	local reason="$2"
 	local answer="$3"
 	local DRY_RUN="$4"
+	local FORCE_BUILD_REPO="$5"
 	local file_cnt count hsize ret
 
-	file_cnt=$(wc -l ${filelist} | awk '{print $1}')
-	if [ ${file_cnt} -eq 0 ]; then
-		msg "No ${reason} to cleanup"
-		return 2
+	if [ ${FORCE_BUILD_REPO} -eq 0 ]; then
+		file_cnt=$(wc -l ${filelist} | awk '{print $1}')
+		if [ ${file_cnt} -eq 0 ]; then
+			msg "No ${reason} to cleanup"
+			return 2
+		fi
 	fi
 
 	msg_n "Calculating size for found files..."

--- a/src/share/poudriere/distclean.sh
+++ b/src/share/poudriere/distclean.sh
@@ -191,7 +191,7 @@ comm -1 -3 ${DISTFILES_LIST}.expected ${DISTFILES_LIST}.actual \
 
 ret=0
 do_confirm_delete "${DISTFILES_LIST}.unexpected" "stale distfiles" \
-    "${answer}" "${DRY_RUN}" || ret=$?
+    "${answer}" "${DRY_RUN}" "0" || ret=$?
 if [ ${ret} -eq 2 ]; then
 	exit 0
 fi

--- a/src/share/poudriere/logclean.sh
+++ b/src/share/poudriere/logclean.sh
@@ -217,7 +217,7 @@ echo " done"
 ret=0
 do_confirm_delete "${OLDLOGS}" \
     "${reason}" \
-    "${answer}" "${DRY_RUN}" || ret=$?
+    "${answer}" "${DRY_RUN}" "0" || ret=$?
 # ret = 2 means no files were deleted, but let's still
 # cleanup other broken/stale files and links.
 logs_deleted=0
@@ -239,7 +239,7 @@ echo " done"
 ret=0
 do_confirm_delete "${OLDLOGS}" \
     "${reason}" \
-    "${answer}" "${DRY_RUN}" || ret=$?
+    "${answer}" "${DRY_RUN}" "0" || ret=$?
 
 if [ ${DRY_RUN} -eq 0 ]; then
 	msg_n "Removing broken legacy latest-per-pkg symlinks (no filter)..."

--- a/src/share/poudriere/pkgclean.sh
+++ b/src/share/poudriere/pkgclean.sh
@@ -48,6 +48,7 @@ Options:
     -p tree     -- Which ports tree to use for packages
     -r          -- With -C delete reverse dependencies too
     -R          -- Clean RESTRICTED packages after building
+    -u          -- Force rebuilding and signing the repo
     -v          -- Be verbose; show more information. Use twice to enable
                    debug output
     -y          -- Assume yes when deleting and do not confirm
@@ -61,13 +62,14 @@ SETNAME=""
 DRY_RUN=0
 DO_ALL=0
 BUILD_REPO=1
+FORCE_BUILD_REPO=0
 OVERLAYS=""
 CLEAN_LISTED=0
 CLEAN_RDEPS=0
 
 [ $# -eq 0 ] && usage
 
-while getopts "AaCj:J:f:nNO:p:rRvyz:" FLAG; do
+while getopts "AaCj:J:f:nNO:p:rRuvyz:" FLAG; do
 	case "${FLAG}" in
 		A)
 			DO_ALL=1
@@ -113,6 +115,9 @@ while getopts "AaCj:J:f:nNO:p:rRvyz:" FLAG; do
 			;;
 		R)
 			NO_RESTRICTED=1
+			;;
+		u)
+			FORCE_BUILD_REPO=1
 			;;
 		v)
 			VERBOSE=$((VERBOSE + 1))
@@ -373,7 +378,7 @@ done
 
 ret=0
 do_confirm_delete "${BADFILES_LIST}" "stale packages" \
-    "${answer}" "${DRY_RUN}" || ret=$?
+    "${answer}" "${DRY_RUN}" "${FORCE_BUILD_REPO}" || ret=$?
 if [ ${ret} -eq 2 ]; then
 	exit 0
 fi


### PR DESCRIPTION
Sometimes I manually tweak the actual repo packages (add packages fetched from official repos for example), and then I need to rebuild and resign it.

This patch add a -u option to pkgclean to do that.