### PR TITLE
Try to fix `poudriere options` when specifying ports with flavor

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -45,7 +45,8 @@ was_a_testport_run() {
 # Return true if in a bulk or other jail run that needs to shutdown the jail
 was_a_jail_run() {
 	was_a_bulk_run ||  [ "${SCRIPTNAME}" = "pkgclean.sh" ] || \
-	    [ "${SCRIPTNAME}" = "foreachport.sh" ]
+	    [ "${SCRIPTNAME}" = "foreachport.sh" ] || \
+	    [ "${SCRIPTNAME}" = "options.sh" ]
 }
 schg_immutable_base() {
 	[ "${IMMUTABLE_BASE}" = "schg" ] || return 1

--- a/src/share/poudriere/options.sh
+++ b/src/share/poudriere/options.sh
@@ -193,6 +193,11 @@ options_cleanup() {
 }
 setup_makeconf ${__MAKE_CONF} "${JAILNAME}" "${PTNAME}" "${SETNAME}"
 
+# to cycle ports this command calls the listed_ports function which
+# needs to check for features.
+# This check needs the P_PORTS_FEATURES to be populated by
+# fetch_global_port_vars which requires a running jail to work properly.
+# So provide a running jail here.
 MASTERNAME=${JAILNAME}-${PTNAME}${SETNAME:+-${SETNAME}}
 _mastermnt MASTERMNT
 

--- a/src/share/poudriere/options.sh
+++ b/src/share/poudriere/options.sh
@@ -190,7 +190,6 @@ export __MAKE_CONF
 CLEANUP_HOOK=options_cleanup
 options_cleanup() {
 	rm -f ${__MAKE_CONF}
-	jail_stop
 }
 setup_makeconf ${__MAKE_CONF} "${JAILNAME}" "${PTNAME}" "${SETNAME}"
 

--- a/src/share/poudriere/options.sh
+++ b/src/share/poudriere/options.sh
@@ -190,6 +190,7 @@ export __MAKE_CONF
 CLEANUP_HOOK=options_cleanup
 options_cleanup() {
 	rm -f ${__MAKE_CONF}
+	jail_stop
 }
 setup_makeconf ${__MAKE_CONF} "${JAILNAME}" "${PTNAME}" "${SETNAME}"
 
@@ -230,6 +231,3 @@ for originspec in $(listed_ports show_moved); do
 			${RECURSE_COMMAND}
 	fi
 done
-
-# Make sure to cleanup
-jail_stop

--- a/src/share/poudriere/options.sh
+++ b/src/share/poudriere/options.sh
@@ -193,6 +193,19 @@ options_cleanup() {
 }
 setup_makeconf ${__MAKE_CONF} "${JAILNAME}" "${PTNAME}" "${SETNAME}"
 
+MASTERNAME=${JAILNAME}-${PTNAME}${SETNAME:+-${SETNAME}}
+_mastermnt MASTERMNT
+
+export MASTERNAME
+export MASTERMNT
+
+PREPARE_PARALLEL_JOBS=1
+PARALLEL_JOBS=1
+
+jail_start "${JAILNAME}" "${PTNAME}" "${SETNAME}"
+
+fetch_global_port_vars
+
 export TERM=${SAVED_TERM}
 for originspec in $(listed_ports show_moved); do
 	originspec_decode "${originspec}" origin flavor
@@ -217,3 +230,6 @@ for originspec in $(listed_ports show_moved); do
 			${RECURSE_COMMAND}
 	fi
 done
+
+# Make sure to cleanup
+jail_stop


### PR DESCRIPTION
As reported in bug #1083 `poudriere options` is giving errors if it is passed ports specifying a flavor.

The `options.sh` script fails to populate the `P_PORTS_FEATURES` variable.

I have created this patch that starts a full jail so the `port_var_fetch` function can work and populate it.

This function is called via the `listed_ports` function call.

I'm not sure this is the correct approach, but is working fine here.