### PR TITLE
add support for overlay directories by using PKGCATEGORY

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -5514,7 +5514,7 @@ deps_fetch_vars() {
 	local ignore_var="$6"
 	local _pkgname _pkg_deps _lib_depends= _run_depends= _selected_options=
 	local _changed_options= _changed_deps= _lookup_flavors=
-	local _existing_origin _existing_originspec categories _ignore
+	local _existing_origin _existing_originspec pkgcategory _ignore
 	local _forbidden _default_originspec _default_pkgname _no_arch
 	local origin _dep _new_pkg_deps
 	local _origin_flavor _flavor _flavors
@@ -5554,7 +5554,7 @@ deps_fetch_vars() {
 			PKGNAME${_origin_subpkg:+.${_origin_subpkg}} _pkgname \
 			${_lookup_flavors} \
 			'${_DEPEND_SPECIALS:C,^${PORTSDIR}/,,}' _depend_specials \
-			CATEGORIES categories \
+			PKGCATEGORY pkgcategory \
 			IGNORE _ignore \
 			FORBIDDEN _forbidden \
 			NO_ARCH:Dyes _no_arch \
@@ -5573,7 +5573,7 @@ deps_fetch_vars() {
 			PKGNAME _pkgname \
 			${_lookup_flavors} \
 			'${_DEPEND_SPECIALS:C,^${PORTSDIR}/,,}' _depend_specials \
-			CATEGORIES categories \
+			PKGCATEGORY pkgcategory \
 			IGNORE _ignore \
 			FORBIDDEN _forbidden \
 			NO_ARCH:Dyes _no_arch \
@@ -5596,7 +5596,7 @@ deps_fetch_vars() {
 	# - Pkg not registering the dependency
 	# - Having delete_old_pkg later remove it due to the origin fetched
 	#   from pkg-query not existing.
-	if [ "${categories%% *}" != "${origin%%/*}" ]; then
+	if [ "${pkgcategory}" != "${origin%%/*}" ]; then
 		msg_error "${COLOR_PORT}${origin}${COLOR_RESET} has incorrect CATEGORIES, first should be '${origin%%/*}'.  Please contact maintainer of the port to fix this."
 		return 1
 	fi


### PR DESCRIPTION
Problem:

poudriere check for sane CATEGORIES fails on ports using custom PKGCATEGORY


Example:

```
mkdir /usr/ports/local
echo "PKGCATEGORY=local" > /usr/ports/local/Makefile.inc
echo "PKGNAMESUFFIX?=-local" >> /usr/ports/local/Makefile.inc
rsync -a /usr/ports/ports-mgmt/dialog4ports/ /usr/ports/local/dialog4ports/
echo "local/dialog4ports" > ~/pkglist
poudriere ports -c
poudriere jail -c -v 14.0-RELEASE -a i386 -j 14i386
poudriere bulk -f ~/pkglist -j 14i386

```

Logs:

```
[00:00:00] Creating the reference jail... done
[00:00:00] Mounting system devices for 14i386-default
[00:00:00] Mounting ports/packages/distfiles
[00:00:00] Using packages from previously failed build: /pbuild14/data/packages/14i386-default/.building
[00:00:00] Mounting packages from: /pbuild14/data/packages/14i386-default
[00:00:00] Appending to make.conf: /usr/local/etc/poudriere.d/make.conf
/etc/resolv.conf -> /pbuild14/data/.m/14i386-default/ref/etc/resolv.conf
[00:00:00] Starting jail 14i386-default
[00:00:00] Will build as nobody: (65534:65534)
[00:00:01] Logs: /pbuild14/data/logs/bulk/14i386-default/2023-11-27_07h53m38s
[00:00:01] Loading MOVED for /pbuild14/data/.m/14i386-default/ref/usr/ports
[00:00:01] Ports supports: FLAVORS SELECTED_OPTIONS
[00:00:01] Gathering ports metadata
[00:00:01] Warning: (local/dialog4ports): Error: local/dialog4ports has incorrect CATEGORIES, first should be 'local'.  Please contact maintainer of the port to fix this.
[00:00:01] Error: Fatal errors encountered gathering ports metadata 
[00:00:01] Cleaning up
14i386-default: removed
14i386-default-n: removed
[00:00:01] Unmounting file systems

```

Diagnostics:

in bsd.port.mk the origin of a port is defined by PKGCATEGORY
`PKGORIGIN?=           ${PKGCATEGORY}/${PORTDIRNAME}`

which defaults to the first entry in CATEGORIES:
`PKGCATEGORY?= ${_CATEGORY}`

The Ports system handles such overlay pretty well.
This was used by others as well, for example by portrookies.

This patch solves the problem for me.

