### PR TITLE
image_zfs: Fix GPT+ZFS boot partition creation

### DIFF
--- a/src/share/poudriere/image_zfs.sh
+++ b/src/share/poudriere/image_zfs.sh
@@ -169,7 +169,10 @@ zfs_generate()
 		fi
 		if [ "${arch}" == "amd64" ] || [ "${arch}" == "i386" ]; then
 			pmbr="-b ${mnt}/boot/pmbr"
-			gptboot="-p freebsd-boot::512k=${mnt}/boot/gptzfsboot"
+			gptbootfilename=$(mktemp /tmp/gptzfsboot.XXXXXX)
+			cp "$mnt"/boot/gptzfsboot "$gptbootfilename"
+			truncate -s 512k "$gptbootfilename"
+			gptboot="-p freebsd-boot:=${gptbootfilename}"
 		fi
 		mkimg -s gpt ${pmbr} \
 			  -p efi:=${espfilename} \
@@ -179,6 +182,7 @@ zfs_generate()
 			  ${SWAPLAST} \
 			  -o "${OUTPUTDIR}/${FINALIMAGE}"
 		rm -rf ${espfilename}
+		rm -f "$gptbootfilename"
 		;;
 	esac
 }


### PR DESCRIPTION
Apparently #962 never really fixed the issue, just avoided a failed assertion.

Fix it by making a disposable copy of the gptzfsboot file, and truncate (or rather expand) it to 512K before passing it to mkimg as the freebsd-boot partition, in order to keep the same partition size that bsdinstall uses.

Fixes:	#1098