### PR TITLE
Remove trailing `_*` from pkg version

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -5683,6 +5683,7 @@ ensure_pkg_installed() {
 		injail_ver=${injail_ver##*/}
 		injail_ver=${injail_ver##*-}
 		injail_ver=${injail_ver%.*}
+		injail_ver=${injail_ver%_*}
 		host_ver=$(/usr/local/sbin/pkg-static -v)
 		if [ "${host_ver}" = "${injail_ver}" ]; then
 			cp -f /usr/local/sbin/pkg-static "${mnt}/${PKG_BIN}"


### PR DESCRIPTION
The `pkg-static -v` check for the running version does not include PORTREVISION information, so strip that from the version obtained via the package file.

Fixes #1009