### PR TITLE
jail: Fix pkgbase jail creation

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -8438,6 +8438,17 @@ svn_git_checkout_method() {
 				;;
 			esac
 			;;
+		pkgbase*)
+			case "${SOURCES_URL}" in
+			http://*) ;;
+			https://*) ;;
+			file://*) ;;
+			*)
+				msg_error "Invalid pkgbase url"
+				return 1
+				;;
+			esac
+			;;
 		*)
 			msg_error "-U only valid with git and svn methods"
 			return 1


### PR DESCRIPTION
Since the official repo aren't using 'latest' directory fix how we construct the pkgbase url.
Now it's flexible enough to accomodate for most use case. An example on how to create a 15-CURRENT jail:
poudriere jail -j pkgbase-main-weekly -c -m pkgbase=base_weekly -U https://pkg.freebsd.org/ -v 15 -a amd64

This will use the base_weekly repository, while
poudriere jail -j pkgbase-main-weekly -c -m pkgbase=base_latest -U https://pkg.freebsd.org/ -v 15 -a amd64 will use the base_latest one.

This also install the FreeBSD-src-sys package so we can build kmods in the jail.

Sponsored by:	Beckhoff Automation GmbH & Co. KG