### PR TITLE
Remove jail -c -m allbsd

### DIFF
--- a/completions/bash/poudriere
+++ b/completions/bash/poudriere
@@ -275,7 +275,7 @@ _poudriere()
                         ;;
                     -m)
                         # TODO: Complete paths for src= and tar=.
-                        COMPREPLY=($(compgen -W "allbsd ftp-archive ftp git http null src= svn svn+file svn+http svn+https svn+ssh tar= url=" -- "$cur"))
+                        COMPREPLY=($(compgen -W "ftp-archive ftp git http null src= svn svn+file svn+http svn+https svn+ssh tar= url=" -- "$cur"))
                         if [[ ${#COMPREPLY[@]} == 1 && $COMPREPLY == *= ]]; then
                             compopt -o nospace
                         fi

--- a/completions/zsh/_poudriere
+++ b/completions/zsh/_poudriere
@@ -83,7 +83,7 @@ _jail=(
 	'-f[fs name (tank/jails/myjail) if fs is "none" then do not create on ZFS]::fs:_files -/'
 	'-K[build the jail with the kernel]::kernelname'
 	'-M[mountpoint]::mountpoint:_files -/'
-	'-m[when used with -c, overrides the default method for obtaining and building the jail.]::method:(allbsd ftp-archive ftp git http null src svn svn+file svn+http svn+https svn+ssh tar url)'
+	'-m[when used with -c, overrides the default method for obtaining and building the jail.]::method:(ftp-archive ftp git http null src svn svn+file svn+http svn+https svn+ssh tar url)'
 	'-P[specify a patch to apply to the source before building]::patch:_files -/'
 	'-S[specify a path to the source tree to be used]::srcpath:_files -/'
 	'-D[do a full git clone without --depth]'

--- a/src/man/poudriere-jail.8
+++ b/src/man/poudriere-jail.8
@@ -195,9 +195,6 @@ The default is
 .Pp
 Pre-built distribution options:
 .Bl -tag -width "ftp-archive"
-.It Cm allbsd
-Fetch from
-.Lk http://www.allbsd.org .
 .It Cm ftp
 Fetch from the host specified in the
 .Va FREEBSD_HOST

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -62,7 +62,7 @@ Options:
     -m method     -- When used with -c, overrides the default method for
                      obtaining and building the jail. See poudriere(8) for more
                      details. Can be one of:
-                       'allbsd', 'ftp-archive', 'ftp', 'freebsdci', 'http',
+                       'ftp-archive', 'ftp', 'freebsdci', 'http',
 		       'null', 'src=PATH', 'tar=PATH', 'url=URL', or
 		       '{git,svn}{,+http,+https,+file,+ssh}' (e.g., 'git+https').
                      The default is '${METHOD_DEF}'.
@@ -342,7 +342,7 @@ update_jail() {
 		make -C ${SRC_BASE} delete-old delete-old-libs DESTDIR=${JAILMNT} BATCH_DELETE_OLD_FILES=yes
 		markfs clean ${JAILMNT}
 		;;
-	allbsd|gjb|url=*|freebsdci)
+	gjb|url=*|freebsdci)
 		[ -z "${VERSION}" ] && VERSION=$(jget ${JAILNAME} version)
 		[ -z "${ARCH}" ] && ARCH=$(jget ${JAILNAME} arch)
 		delete_jail
@@ -724,7 +724,6 @@ install_from_ftp() {
 			esac
 			;;
 		url=*) URL=${METHOD##url=} ;;
-		allbsd) URL="https://pub.allbsd.org/FreeBSD-snapshots/${ARCH%%.*}-${ARCH##*.}/${V}-JPSNAP/ftp" ;;
 		ftp-archive) URL="http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/${ARCH}/${V}" ;;
 		freebsdci) URL="https://artifact.ci.freebsd.org/snapshot/${V}/latest_tested/${ARCH%%.*}/${ARCH##*.}" ;;
 		esac
@@ -787,7 +786,6 @@ install_from_ftp() {
 						;;
 				esac
 				;;
-			allbsd) URL="https://pub.allbsd.org/FreeBSD-snapshots/${ARCH%%.*}-${ARCH##*.}/${V}-JPSNAP/ftp" ;;
 			ftp-archive) URL="http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/${ARCH%%.*}/${ARCH##*.}/${V}" ;;
 			freebsdci) URL="https://artifact.ci.freebsd.org/snapshot/${V}/latest_tested/${ARCH%%.*}/${ARCH##*.}" ;;
 			url=*) URL=${METHOD##url=} ;;
@@ -902,19 +900,6 @@ create_jail() {
 	case ${METHOD} in
 	ftp|http|gjb|ftp-archive|freebsdci|url=*)
 		FCT=install_from_ftp
-		;;
-	allbsd)
-		FCT=install_from_ftp
-		ALLBSDVER=`fetch -qo - \
-			https://pub.allbsd.org/FreeBSD-snapshots/${ARCH}-${ARCH}/ | \
-			sed -n "s,.*href=\"\(.*${VERSION}.*\)-JPSNAP/\".*,\1,p" | \
-			sort -k 3 -t - -r | head -n 1 `
-		[ -z ${ALLBSDVER} ] && err 1 "Unknown version $VERSION"
-
-		IFS=-
-		set -- ${ALLBSDVER}
-		unset IFS
-		RELEASE="${ALLBSDVER}-JPSNAP/ftp"
 		;;
 	svn*)
 		[ -x "${SVN_CMD}" ] || \
@@ -1277,7 +1262,6 @@ if ! svn_git_checkout_method "${SOURCES_URL}" "${METHOD}" \
 		usage
 	fi
 	case "${METHOD}" in
-	allbsd) ;;
 	csup) ;;
 	freebsdci) ;;
 	ftp) ;;


### PR DESCRIPTION
It has been over 9 years since allbsd.org was updated.  The last snapshots are for HEAD post 10.0 and not particularly useful.  If it starts updating again someday this code can be restored.  For now it just gives false hope.