### PR TITLE
Update common.sh

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -3161,6 +3161,9 @@ jail_start() {
 	injail id >/dev/null 2>&1 || \
 	    err $? "Unable to execute id(1) in jail. Emulation or ABI wrong."
 
+	# Generate /var/run/os-release
+	injail service os-release start
+ 
 	portbuild_gid=$(injail pw groupshow "${PORTBUILD_GROUP}" 2>/dev/null | cut -d : -f3 || :)
 	if [ -z "${portbuild_gid}" ]; then
 		msg_n "Creating group ${PORTBUILD_GROUP}"


### PR DESCRIPTION
Some build system try to extract OS values from /etc/os-release, so populate it.

This is a workaround for [issue 1123](https://github.com/freebsd/poudriere/issues/1123).
But I don’t understand why it is not started by default (as instructed in /etc/defaults/rc.conf).
