### PR TITLE
Use gptboot.efi in place of loader.efi to support bootme and bootonce

### DIFF
--- a/src/share/poudriere/image_firmware.sh
+++ b/src/share/poudriere/image_firmware.sh
@@ -132,7 +132,7 @@ firmware_generate()
 		fi
 	fi
 	espfilename=$(mktemp /tmp/efiboot.XXXXXX)
-	make_esp_file ${espfilename} ${ESP_SIZE} ${WRKDIR}/world/boot/loader.efi
+	make_esp_file ${espfilename} ${ESP_SIZE} ${WRKDIR}/world/boot/gptboot.efi
 	mkimg -s gpt -C ${IMAGESIZE} -b ${mnt}/boot/pmbr \
 		-p efi:=${espfilename} \
 		-p freebsd-boot:=${mnt}/boot/gptboot \


### PR DESCRIPTION
loader.efi ignores the GPT attributes bootme and bootonce: So after upgrading firmware image the system is still wrongly booting the first UFS partition found and not the new one. Using gptboot.efi fix this behaviour.