### PR TITLE
Generate the upgrade image with the firmware image

### DIFF
--- a/src/share/poudriere/image_firmware.sh
+++ b/src/share/poudriere/image_firmware.sh
@@ -144,6 +144,7 @@ firmware_generate()
 		${SWAPLAST} \
 		-o "${OUTPUTDIR}/${FINALIMAGE}"
 	rm -rf ${espfilename}
+ 	mv ${WRKDIR}/raw.img "${OUTPUTDIR}/${IMAGENAME}-upgrade.img
 }
 
 rawfirmware_check()


### PR DESCRIPTION
While generating the full firmware image (full disk image), we need to generate the upgrade-only image too (OS partition) to be used to upgrade older installed firmware.