### PR TITLE
Enable space optimisation and disable minfree on read-only firmware i…

### DIFF
--- a/src/share/poudriere/image_firmware.sh
+++ b/src/share/poudriere/image_firmware.sh
@@ -112,10 +112,10 @@ firmware_build()
 	FTMPDIR=`mktemp -d -t poudriere-firmware` || exit 1
 	# Set proper permissions to this empty directory: /cfg (so /etc) and /data once mounted will inherit them
 	chmod -R 755 ${FTMPDIR}
-	makefs -B little -s ${CFG_SIZE} ${WRKDIR}/cfg.img ${FTMPDIR}
-	makefs -B little -s ${DATA_SIZE} ${WRKDIR}/data.img ${FTMPDIR}
+	makefs -B little -s ${CFG_SIZE} -o optimization=space,minfree=0,label=cfg ${WRKDIR}/cfg.img ${FTMPDIR}
+	makefs -B little -s ${DATA_SIZE} -o label=data ${WRKDIR}/data.img ${FTMPDIR}
 	rm -rf ${FTMPDIR}
-	makefs -B little -s ${OS_SIZE}m -o label=${IMAGENAME} \
+	makefs -B little -s ${OS_SIZE}m -o optimization=space,minfree=0,label=${IMAGENAME} \
 		-o version=2 ${WRKDIR}/raw.img ${WRKDIR}/world
 }
 
@@ -223,10 +223,10 @@ rawfirmware_build()
 	FTMPDIR=`mktemp -d -t poudriere-firmware` || exit 1
 	# Set proper permissions to this empty directory: /cfg (so /etc) and /data once mounted will inherit them
 	chmod -R 755 ${FTMPDIR}
-	makefs -B little -s ${CFG_SIZE} ${WRKDIR}/cfg.img ${FTMPDIR}
-	makefs -B little -s ${DATA_SIZE} ${WRKDIR}/data.img ${FTMPDIR}
+	makefs -B little -s ${CFG_SIZE} -o optimization=space,minfree=0,label=cfg ${WRKDIR}/cfg.img ${FTMPDIR}
+	makefs -B little -s ${DATA_SIZE} -o label=data ${WRKDIR}/data.img ${FTMPDIR}
 	rm -rf ${FTMPDIR}
-	makefs -B little -s ${OS_SIZE}m -o label=${IMAGENAME} \
+	makefs -B little -s ${OS_SIZE}m -o optimization=space,minfree=0,label=${IMAGENAME} \
 		-o version=2 ${WRKDIR}/raw.img ${WRKDIR}/world
 }
 


### PR DESCRIPTION
…mages

There is no need to kept 8% space on read-only filesystem. And while here, optimize it for space too and set ufs labels.

Example of free space improvement:
```
Filesystem  Size  Used   Avail  Capacity  Mounted on
/dev/md0    899M  749M   78M    91%       /tmp/firmware.before
/dev/md1    899M  749M   149M   83%       /tmp/firmware.after
```