### PR TITLE
Set a GPT label for EFI partition

### DIFF
--- a/src/share/poudriere/image_firmware.sh
+++ b/src/share/poudriere/image_firmware.sh
@@ -134,7 +134,7 @@ firmware_generate()
 	espfilename=$(mktemp /tmp/efiboot.XXXXXX)
 	make_esp_file ${espfilename} ${ESP_SIZE} ${WRKDIR}/world/boot/loader.efi
 	mkimg -s gpt -C ${IMAGESIZE} -b ${mnt}/boot/pmbr \
-		-p efi/efiboot:=${espfilename} \
+		-p efi/efiboot0:=${espfilename} \
 		-p freebsd-boot:=${mnt}/boot/gptboot \
 		-p freebsd-ufs/${IMAGENAME}1:=${WRKDIR}/raw.img \
 		-p freebsd-ufs/${IMAGENAME}2:=${WRKDIR}/raw.img \

--- a/src/share/poudriere/image_firmware.sh
+++ b/src/share/poudriere/image_firmware.sh
@@ -134,7 +134,7 @@ firmware_generate()
 	espfilename=$(mktemp /tmp/efiboot.XXXXXX)
 	make_esp_file ${espfilename} ${ESP_SIZE} ${WRKDIR}/world/boot/loader.efi
 	mkimg -s gpt -C ${IMAGESIZE} -b ${mnt}/boot/pmbr \
-		-p efi:=${espfilename} \
+		-p efi/efiboot:=${espfilename} \
 		-p freebsd-boot:=${mnt}/boot/gptboot \
 		-p freebsd-ufs/${IMAGENAME}1:=${WRKDIR}/raw.img \
 		-p freebsd-ufs/${IMAGENAME}2:=${WRKDIR}/raw.img \


### PR DESCRIPTION
This allow to easly update the EFI loader and sync with a standard FreeBSD install.