### PR TITLE
Makefile.am: Move optimization level to AM_CFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,8 +8,7 @@ if MAINTAINER_MODE
 AM_CFLAGS+=	-Wextra -Werror
 endif
 if ADDRESS_SANITIZER
-AM_CFLAGS+=	-fsanitize=address -DADDRESS_SANITIZER -fno-omit-frame-pointer
-CFLAGS+=	-O1
+AM_CFLAGS+=	-fsanitize=address -DADDRESS_SANITIZER -fno-omit-frame-pointer -O1
 endif
 
 awkdir=	$(pkgdatadir)/awk

--- a/Makefile.in
+++ b/Makefile.in
@@ -95,8 +95,7 @@ host_triplet = @host@
 noinst_PROGRAMS = external/sh/mknodes$(EXEEXT) \
 	external/sh/mksyntax$(EXEEXT)
 @MAINTAINER_MODE_TRUE@am__append_1 = -Wextra -Werror
-@ADDRESS_SANITIZER_TRUE@am__append_2 = -fsanitize=address -DADDRESS_SANITIZER -fno-omit-frame-pointer
-@ADDRESS_SANITIZER_TRUE@am__append_3 = -O1
+@ADDRESS_SANITIZER_TRUE@am__append_2 = -fsanitize=address -DADDRESS_SANITIZER -fno-omit-frame-pointer -O1
 pkglibexec_PROGRAMS = clock$(EXEEXT) cpdup$(EXEEXT) dirempty$(EXEEXT) \
 	dirwatch$(EXEEXT) locked_mkdir$(EXEEXT) nc$(EXEEXT) \
 	poudriered$(EXEEXT) ptsort$(EXEEXT) pwait$(EXEEXT) \
@@ -557,7 +556,7 @@ AUTOMAKE = @AUTOMAKE@
 AWK = @AWK@
 CC = @CC@
 CCDEPMODE = @CCDEPMODE@
-CFLAGS = @CFLAGS@ $(am__append_3)
+CFLAGS = @CFLAGS@
 CPPFLAGS = @CPPFLAGS@
 CSCOPE = @CSCOPE@
 CTAGS = @CTAGS@


### PR DESCRIPTION
Defining CFLAGS in Makefile.am is not recommended and generates a warning in autoreconf stage. Since CFLAGS is a user variable, it should not be directly modified by autoreconf.

Warning generated by `./autogen.sh`
```
Makefile.am:12: warning: 'CFLAGS' is a user variable, you should not override it;
Makefile.am:12: use 'AM_CFLAGS' instead
```

This fixes commit 52fff5ef4bcf8fa67dc90819494b9a43b9131122