### PR TITLE
Fetch packages after removing what we need to rebuild, not before that.

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -9233,7 +9233,6 @@ prepare_ports() {
 		else
 			trim_ignored
 		fi
-		download_from_repo
 		if ! ensure_pkg_installed; then
 			delete_all_pkgs "pkg bootstrap missing: unable to inspect existing packages"
 		fi
@@ -9262,6 +9261,7 @@ prepare_ports() {
 			msg "Skipping recursive rebuild"
 		fi
 
+		download_from_repo
 		delete_stale_symlinks_and_empty_dirs
 		delete_stale_pkg_cache
 		download_from_repo_post_delete


### PR DESCRIPTION
I think, this change from PR #1101 is still actual:

https://github.com/freebsd/poudriere/pull/1101
https://github.com/freebsd/poudriere/pull/1101/commits/bc6b07bd3beebd89c238d677e99843d1519efc4a