### PR TITLE
Allow MAX_EXECUTION_TIME be customized for individual packages

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -5831,6 +5831,7 @@ build_pkg() {
 
 	pkgbase="${pkgname%-*}"
 	_gsub_var_name "${pkgbase}" pkgname_varname
+	eval "MAX_EXECUTION_TIME=\${MAX_EXECUTION_TIME_${pkgname_varname}:-${MAX_EXECUTION_TIME:-}}"
 	eval "MAX_FILES=\${MAX_FILES_${pkgname_varname}:-${DEFAULT_MAX_FILES}}"
 	eval "MAX_MEMORY=\${MAX_MEMORY_${pkgname_varname}:-${MAX_MEMORY:-}}"
 	if [ -n "${MAX_MEMORY}" -o -n "${MAX_FILES}" ]; then


### PR DESCRIPTION
This is needed to allow more time for www/chromium build, among potential other uses.