### PR TITLE
poudriere.css: Adapt to latest DataTables style to avoid unreadable tables

### DIFF
--- a/src/share/poudriere/html/assets/poudriere.css
+++ b/src/share/poudriere/html/assets/poudriere.css
@@ -48,43 +48,43 @@
 .layout td {
     border: 0;
 }
-.built {
+.built:not(table), table.built thead {
     background-color: #00cc00 !important;
 }
 .built .row1 {
     background-color: #00ff00;
 }
-.failed {
+.failed:not(table), table.failed thead {
     background-color: #e00000 !important;
 }
 .failed .row1 {
     background-color: #ff0000;
 }
-.skipped {
+.skipped:not(table), table.skipped thead {
     background-color: #cc6633 !important;
 }
 .skipped .row1 {
     background-color: #aa6734;
 }
-.ignored {
+.ignored:not(table), table.ignored thead {
     background-color: #ff9900 !important;
 }
 .ignored .row1 {
     background-color: #ff6f00;
 }
-.fetched {
+.fetched:not(table), table.fetched thead {
     background-color: #228b22 !important;
 }
 .fetched .row1 {
     background-color: #225b22;
 }
-.remaining {
+.remaining:not(table), table.remaining thead {
     background-color: #e3e3e3 !important;
 }
 .remaining .row1 {
     background-color: #bcbcbc;
 }
-.queued {
+.queued:not(table), table.queued thead {
     background-color: #aaa !important;
 }
 .queued .row1 {


### PR DESCRIPTION
The newer DataTables imported in ce2146e99efc ("Update DataTables to
1.13.8") started setting every other row to transparent. Since we add
the built etc classes to the whole table, this means the entire table's
background colour is green etc, and so the transparent rows now allow
that colour to shine through, making it hard to read the text.

Adapt the CSS selectors to only colour the thead within the whole table
so that the rows are restored to being uncoloured, less garish and
rather more readable. Note that these classes are also used for the
status display at the top, so we need to handle them on things other
than tables too, where we continue to just colour the whole element.

Fixes #1114

Fixes:	ce2146e99efc ("Update DataTables to 1.13.8")
