### PR TITLE
First draft for a Fetch Only check

### DIFF
--- a/src/etc/poudriere.conf.sample
+++ b/src/etc/poudriere.conf.sample
@@ -385,3 +385,5 @@ DISTFILES_CACHE=/usr/ports/distfiles
 # be fetched.
 # Default: everything
 #PACKAGE_FETCH_WHITELIST="gcc* rust llvm*"
+# The build will fail, if any package on this list cannot be fetched
+#PACKAGE_FETCH_ONLY=""

--- a/src/man/poudriere-bulk.8
+++ b/src/man/poudriere-bulk.8
@@ -210,8 +210,9 @@ See
 .Sy PACKAGE_FETCH_BRANCH ,
 .Sy PACKAGE_FETCH_URL ,
 .Sy PACKAGE_FETCH_BLACKLIST ,
+.Sy PACKAGE_FETCH_WHITELIST ,
 and
-.Sy PACKAGE_FETCH_WHITELIST
+.Sy PACKAGE_FETCH_ONLY
 in
 .Pa poudriere.conf.sample .
 The entries in the lists will be matched against package names without versions.

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -4501,7 +4501,7 @@ check_fetch_only_list() {
 	[ $# -eq 0 ] || eargs check_fetch_only_list
 	local pkgname pkgbase fopkg_glob
 
-	if [ -z ${PACKAGE_FETCH_ONLY} ]; then
+	if [ -z "${PACKAGE_FETCH_ONLY}" ]; then
 		msg_debug "Fetch only check: Empty list"
 		return
 	fi


### PR DESCRIPTION
This is a first draft for a Fetch Only check funtion. It should offer the functionality described in Issue #1129 .

I have developed the function here on my locally installed version (3.4.1_1) of poudriere. I did a few small tests (undefined configuration, empty list, filled list, entries with asterisk), which at least worked for me.

But I have too little experience in developing poudriere. So I don't know if the function call is in a suitable place. And whether this installation does not interfere with other functions. Therefore I ask you to take a very close look at the whole thing and test it before integration.