### PR TITLE
JavaScript: Prefer latest build date first

### DIFF
--- a/src/share/poudriere/html/assets/poudriere.js
+++ b/src/share/poudriere/html/assets/poudriere.js
@@ -1233,7 +1233,7 @@ function setup_jail() {
         $("td", row).addClass("latest");
       }
     },
-    order: [[0, "asc"]], // Sort by buildname
+    order: [[0, "desc"]], // Sort by buildname
   });
 
   //applyHovering('builds_table');


### PR DESCRIPTION
When viewing the builds page, it's common to want the latest builds to appear first. I suggest making this the default behavior. Therefore, I’ve modified the sorting in the JavaScript to use descending (desc) order instead of ascending (asc).