### PR TITLE
src/share/poudriere/include/pkgqueue.sh: replace 'paste -d' with 'pr …

### DIFF
--- a/src/share/poudriere/include/pkgqueue.sh
+++ b/src/share/poudriere/include/pkgqueue.sh
@@ -566,7 +566,7 @@ pkgqueue_move_ready_to_pool() {
 	set)
 		POOL_BUCKET_DIRS="$(echo "${PKGQUEUE_PRIORITIES}" |
 		    tr ' ' '\n' | LC_ALL=C sort -run |
-		    paste -d ' ' -s -)"
+		    pr -m -t -s' ' -)"
 		;;
 	*)
 		# If there are no buckets then everything to build will fall


### PR DESCRIPTION
…-m -t -s' to fix deal with long lines in POOL_BUCKET_DIRS

On aarch64 final result of long line (over 90 items) looks like "115Z114Z113Z112Z111Z110Z109Z108Z107Z106Z105Z104..." instead of "115 114 113 112 111 110 109 108 107 106 105 104...." which revent to run mkdir for POOL_BUCKET_DIRS list with setted PRIORITY_BOOST knob

[00:00:39] Processing PRIORITY_BOOST
Error: (78387) mkdir:pkgqueue_move_ready_to_pool:269: 115Z114Z113Z112Z111Z110Z109Z108Z107Z106Z105Z104Z103Z102 Z101Z100Z99Z98Z97Z96Z95Z94Z93Z92Z91Z90Z89Z88Z87Z86Z85Z84Z83Z82Z81Z80Z79Z78Z77Z76Z75Z74Z73Z72Z71Z70Z69Z68Z67Z66 Z65Z64Z63Z62Z61Z60Z59Z58Z57Z56Z55Z54Z53Z52Z51Z50Z49Z48Z47Z46Z45Z44Z43Z42Z41Z40Z39Z38Z37Z36Z35Z34Z33Z32Z31Z30 Z29Z28Z27Z26Z25Z24Z23Z22Z21Z20Z19Z18Z17Z16Z15Z14Z13Z12Z11Z10Z9Z8Z7Z6Z5Z4Z3Z2Z1Z0: File name too long Error: (32676) /usr/local/share/poudriere/bulk.sh:pkgqueue_move_ready_to_pool:269: set -e error: status = 1

See https://github.com/freebsd/poudriere/issues/1187 for details