### PR TITLE
image_zfs: use default (fletcher4) checksum algorithm

### DIFF
--- a/src/share/poudriere/image_zfs.sh
+++ b/src/share/poudriere/image_zfs.sh
@@ -67,7 +67,7 @@ zfs_prepare()
 	zpool create \
 		-O mountpoint=/${ZFS_POOL_NAME} \
 		-O canmount=noauto \
-		-O checksum=sha512 \
+		-O checksum=on \
 		-O compression=on \
 		-O atime=off \
 		-t ${zroot} \


### PR DESCRIPTION
fletcher4 is the default as listed in `zfsprops(7)` and `sha512` doesn't seem to be required unless there's some explicit need for a cryptographic hash.