### PR TITLE
Introduce JAILED_DATASET option to poudriere.conf

### DIFF
--- a/src/etc/poudriere.conf.sample
+++ b/src/etc/poudriere.conf.sample
@@ -18,6 +18,14 @@
 # root of the poudriere zfs filesystem, by default /poudriere
 # ZROOTFS=/poudriere
 
+# ZFS dataset relative to ZROOTFS that will be passed into jail using zfs-jail(8)
+# The jail will have full control over this dataset
+# The dataset is recreated from scratch on every jail start and is destroyed
+# when jail is stopped
+# Enabling this feature will set "allow.mount=1", "allow.mount.zfs=1"
+# and "enforce_statfs=1" parameters for the jail
+#JAILED_DATASET=
+
 # the host where to download sets for the jails setup
 # You can specify here a host or an IP
 # replace _PROTO_ by http or ftp


### PR DESCRIPTION
Rationale for the change:

We at $WORK are using Poudriere as a part of the CI process. For a selected set of ports we define `WITH_TESTING_PORTS`, which makes the `test` target a part of the pipeline. It works quite well for many of ports we're using.

However, one of the projects we've developed requires creating a ZFS dataset as part of its tests. The #1175 PR made it possible for `zfs` command to run, but no datasets or pools are visible from within the jail. This follow-up change passes through a throw-away ZFS dataset into the jail and gives full access to it.

I understand that the feature is quite niche, but it doesn't add much complexity to the code, so I hope it will be accepted.