### PR TITLE
Workaround issue with 32bit libraries

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -7311,7 +7311,7 @@ package_libdeps_satisfied() {
 		shlib_name="${shlib%.so*}"
 		case " ${shlibs_provided} " in
 		# Success
-		*" ${shlib} "*) ;;
+		*" ${shlib%:32} "*) ;;
 		# A different version! We need to rebuild to use it.
 		# This supports X.Y.Z for each 0-999.
 		# There is probably a better way to do this. We need to see


### PR DESCRIPTION
Poudriere is forcing rebuilds each and every time for some big packages (llvm, gcc, rust) lamenting some missing libraries like `libc.so.7:32`.

I have created this patch to work around the issue, although I'm not sure this is the correct fix or if there is some more solid issue laying behind it.

But I hope this can help discover what is wrong, and be used as a temporary band-aid.