### PR TITLE
auto_lib_depends: stop considering LIB_DEPENDS as RUN_DEPENDS

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -6936,7 +6936,14 @@ _delete_old_pkg() {
 		# which will avoida all of the injail hacks
 
 		# pkgname-lib_deps pkgname-run_deps
-		for td in lib run; do
+		dep_types=""
+		if have_ports_feature AUTO_LIB_DEPENDS; then
+			dep_types="run"
+		else
+			dep_types="lib run"
+		fi
+
+		for td in ${dep_types}; do
 			shash_remove "pkgname-${td}_deps" "${new_pkgname}" \
 			raw_deps || raw_deps=
 			for d in ${raw_deps}; do


### PR DESCRIPTION
if the ports tree have the AUTO_LIB_DEPENDS feature flag, then it means it stops registring the LIB_DEPENDS as RUN_DEPENDS to only rely on shlibs_required/shlibs_provides which means poudriere has to stop analysing for LIB_DEPENDS to check if they changed between the already compiled version of the packages and the current port.