### PR TITLE
jail -d: Properly pass -C argument

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -1365,7 +1365,7 @@ shift $((OPTIND-1))
 post_getopts
 
 METHOD=${METHOD:-${METHOD_DEF}}
-CLEANJAIL=${CLEAN:-none}
+CLEANJAIL=${CLEANJAIL:-none}
 if [ -n "${JAILNAME}" -a "${COMMAND}" != "create" ]; then
 	_jget ARCH ${JAILNAME} arch || :
 	_jget JAILFS ${JAILNAME} fs || :


### PR DESCRIPTION
The argument for CLEANJAIL via OPTARG is never passed down as it should.

Fixes: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=247448