### PR TITLE
jail -d: Properly delete '-C logs'

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -176,7 +176,7 @@ delete_jail() {
 	case ${CLEANJAIL} in
 		all) cleandir="${POUDRIERE_DATA}" ;;
 		cache) cleandir="${POUDRIERE_DATA}/cache"; depth=1 ;;
-		logs) cleandir="${POUDRIERE_DATA}/logs"; depth=1 ;;
+		logs) cleandir="${POUDRIERE_DATA}/logs"; depth=5 ;;
 		packages) cleandir="${POUDRIERE_DATA}/packages"; depth=1 ;;
 		wrkdirs) cleandir="${POUDRIERE_DATA}/wkdirs"; depth=1 ;;
 	esac


### PR DESCRIPTION
Per jail logs are not only located at depth 2 'bulk/{JAILNAME}-*/', but also at depth 5 'bulk/latest-per-pkg/{PKGNAME}/{PKGVERSION}/${JAILNAME}-*.log'.

Fixes: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=247448