### PR TITLE
Pass FLAVOR to check_leftovers

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -5420,6 +5420,7 @@ build_port() {
 				    cleanenv injail /usr/bin/env \
 				    ${PORT_FLAGS:+-S "${PORT_FLAGS}"} \
 				    PORTSDIR=${PORTSDIR} \
+				    FLAVOR="${flavor}" \
 				    UID_FILES="${P_UID_FILES}" \
 				    portdir="${portdir}" \
 				    /bin/sh \


### PR DESCRIPTION
At the moment, running `poudriere bulk -Cti devel/glib20@bootstrap` fails with

```
=>> Checking for extra files and directories
grep: /wrkdirs/usr/ports/devel/glib20/work-default/.PLIST.mktmp: No such file or directory
=>> Error: Files or directories left over:
@dir /usr/local/glib-bootstrap
```

Note the `work-default` part of the path that doesn't match the flavor set.