### PR TITLE
testport: do not attempt to deinstall package in non-interactive mode

### DIFF
--- a/src/share/poudriere/testport.sh
+++ b/src/share/poudriere/testport.sh
@@ -469,7 +469,7 @@ msg "Cleaning up"
 injail /usr/bin/make -C "${portdir:?}" -DNOCLEANDEPENDS clean \
     ${MAKE_ARGS}
 
-if [ -z "${POUDRIERE_INTERACTIVE_NO_INSTALL-}" ]; then
+if [ ${INTERACTIVE_MODE} -gt 0 -a -z "${POUDRIERE_INTERACTIVE_NO_INSTALL-}" ]; then
 	msg "Deinstalling package"
 	ensure_pkg_installed
 	injail ${PKG_DELETE} "${PKGNAME:?}"


### PR DESCRIPTION
This fixes a bug where 'poudriere testport' does not run important post-build routines (cleanup, hooks, etc.) because it exits with error while attempting to deinstall a missing package in non-interactive mode.


Error seen when running 'poudriere testport' without interactive mode:

```
Checking integrity... done (0 conflicting)
1 packages requested for removal: 0 locked, 1 missing Error: (60332) /usr/local/share/poudriere/testport.sh:injail_direct:477: set -e error: status = 1 [00:00:54] Cleaning up
[00:00:54] Unmounting file systems
umount: unmount of /usr/local/poudriere/data/.m/pb-default/ref/.p failed: Device busy tmpfs: unmount from /usr/local/poudriere/data/.m/pb-default/ref/.p
```

This bug exists on latest stable version 3.4.2 at the time of writing, with a message saying `UNHANDLED ERROR`.