### PR TITLE
Implement support for generating AppStream metadata

### DIFF
--- a/src/etc/poudriere.conf.sample
+++ b/src/etc/poudriere.conf.sample
@@ -410,3 +410,10 @@ DISTFILES_CACHE=/usr/ports/distfiles
 # The symlinks are only required for the local poudriere for resovling dependencies,
 # they do not need to be uploaded to the CDN.
 #PKG_HASH="no"
+
+# If set to "yes", generate the AppStream metadata for each package built and
+# for the whole repository. Requires ports-mgmt/appstream-generator installed on
+# the host.
+# USE_APPSTREAM="no"
+# APPSTREAM_MEDIA_BASE="https://example.com"
+# APPSTREAM_HTML_BASE="https://example.com"

--- a/src/share/poudriere/bulk.sh
+++ b/src/share/poudriere/bulk.sh
@@ -290,6 +290,18 @@ fi
 
 commit_packages
 
+if [ ${USE_APPSTREAM} = "yes" ]; then
+	appstream-generator -w ${POUDRIERE_DATA}/appstream/${MASTERNAME} \
+		publish \
+		${MASTERNAME}
+	# TODO:
+	if [ "${IT_IS_TIME_TO_CLEANUP_APPSTREAM}" = "yes" ]; then
+		appstream-generator -w ${POUDRIERE_DATA}/appstream/${MASTERNAME} \
+			cleanup \
+			${MASTERNAME}
+	fi
+fi
+
 set +e
 
 show_build_results


### PR DESCRIPTION
TL;DR version:
This is required to have fancy app descriptions in GUI software management applications like Plasma Discover or Gnome Software: https://arrowd.name/discover-appstream.jpg

Long version:
AppStream is a spec that describes software components and a tooling to produce and consume the software's metadata.

The process begins with a tool called `appstream-generator` that takes OS packages as input and analyzes it. It can analyze a whole repo, but this is slow because it requires unpacking each package. Another way to use it is to feed it an unpacked package (STAGEDIR in our terms), which is much faster. After performing the analysis and if the package is deemed "interesting" for AppStream, it gets added to the appstream-generator's internal DB.

After all the info is gathered into DB, one should run `appstream-generator publish` to produce a set of files that represent the software catalog of our package repo. These files should be hosted somewhere and be synchronized with the pkg repo.

On the client side the user enables the `ports-mgmt/pkg-appstream` plugin that downloads software catalog during the `pkg update` and place it into appropriate location (`/var/db`). Finally, the consumers of the AppStream metadata pick it from there.

This change makes Poudriere run the `appstream-generator` steps
* During `testport` at the end of the successful build
* During `bulk` after each package's successful build
* At the end of `bulk`