### PR TITLE
bulk -b fetches from custom URLs

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -4512,18 +4512,23 @@ download_from_repo() {
 		pkg_bin="pkg"
 	fi
 	if echo "${packagesite}" | grep -q -i "pkg.freebsd.org"; then
+		repo_name=FreeBSD
+
 		cat >> "${MASTERMNT:?}/etc/pkg/poudriere.conf" <<-EOF
 		FreeBSD: {
 			url: ${packagesite};
 		}
 		EOF
 	else
+		repo_name=custom
+
 		cat >> "${MASTERMNT:?}/etc/pkg/poudriere.conf" <<-EOF
 		FreeBSD: {
-			url: ${packagesite},
-			mirror_type: "NONE",
-			pubkey: "NONE",
-			signature_type: "NONE";
+			enabled: false;
+		}
+
+		custom: {
+			url: ${packagesite};
 		}
 		EOF
 	fi
@@ -4533,19 +4538,19 @@ download_from_repo() {
 	# XXX: rquery is supposed to 'update' but it does not on first run.
 	if ! JNETNAME="n" injail env ASSUME_ALWAYS_YES=yes \
 	    PACKAGESITE="${packagesite:?}" \
-	    ${pkg_bin} update -f -r FreeBSD; then
+	    ${pkg_bin} update -f -r ${repo_name}; then
 		msg "Package fetch: Not fetching as remote repository is unavailable."
 		rm -f "${missing_pkgs}"
 		return 0
 	fi
 	# Don't trust pkg-update to return its error
-	if ! injail ${pkg_bin} rquery -U -r FreeBSD %n pkg >/dev/null; then
+	if ! injail ${pkg_bin} rquery -U -r ${repo_name} %n pkg >/dev/null; then
 		msg "Package fetch: Failed to fetch package repository."
 		rm -f "${missing_pkgs}"
 		return 0
 	fi
 
-	remote_pkg_ver="$(injail ${pkg_bin} rquery -U -r FreeBSD %v "${P_PKG_PKGBASE:?}")"
+	remote_pkg_ver="$(injail ${pkg_bin} rquery -U -r ${repo_name} %v "${P_PKG_PKGBASE:?}")"
 	local_pkg_name="${P_PKG_PKGNAME:?}"
 	local_pkg_ver="${local_pkg_name##*-}"
 	case "$(pkg_version -t "${remote_pkg_ver}" "${local_pkg_ver}")" in
@@ -4560,25 +4565,25 @@ download_from_repo() {
 	# (like pkg rquery -U), and it uses various locking that isn't needed
 	# here. Grab all the options for comparison.
 	remote_all_options=$(mktemp -t remote_all_options)
-	injail ${pkg_bin} rquery -U -r FreeBSD '%n %Ok %Ov' > "${remote_all_options}"
+	injail ${pkg_bin} rquery -U -r ${repo_name} '%n %Ok %Ov' > "${remote_all_options}"
 	remote_all_pkgs=$(mktemp -t remote_all_pkgs)
-	injail ${pkg_bin} rquery -U -r FreeBSD '%n %n-%v %?O' > "${remote_all_pkgs}"
+	injail ${pkg_bin} rquery -U -r ${repo_name} '%n %n-%v %?O' > "${remote_all_pkgs}"
 	remote_all_deps=$(mktemp -t remote_all_deps)
-	injail ${pkg_bin} rquery -U -r FreeBSD '%n %dn-%dv' > "${remote_all_deps}"
+	injail ${pkg_bin} rquery -U -r ${repo_name} '%n %dn-%dv' > "${remote_all_deps}"
 	remote_all_annotations=$(mktemp -t remote_all_annotations)
 	remote_all_cats=$(mktemp -t remote_all_cats)
 	case "${IGNORE_OSVERSION-}" in
 	"yes") ;;
 	*)
-		injail ${pkg_bin} rquery -U -r FreeBSD '%n %At %Av' > "${remote_all_annotations}"
-		injail ${pkg_bin} rquery -U -r FreeBSD '%n %C' > "${remote_all_cats}"
+		injail ${pkg_bin} rquery -U -r ${repo_name} '%n %At %Av' > "${remote_all_annotations}"
+		injail ${pkg_bin} rquery -U -r ${repo_name} '%n %C' > "${remote_all_cats}"
 		;;
 	esac
 	abi="$(injail "${pkg_bin}" config ABI)"
 	remote_all_abi=$(mktemp -t remote_all_abi)
-	injail ${pkg_bin} rquery -U -r FreeBSD '%n %q' > "${remote_all_abi}"
+	injail ${pkg_bin} rquery -U -r ${repo_name} '%n %q' > "${remote_all_abi}"
 	remote_all_prefix=$(mktemp -t remote_all_prefix)
-	injail ${pkg_bin} rquery -U -r FreeBSD '%n %p' > "${remote_all_prefix}"
+	injail ${pkg_bin} rquery -U -r ${repo_name} '%n %p' > "${remote_all_prefix}"
 
 	parallel_start
 	wantedpkgs=$(mktemp -t wantedpkgs)
@@ -4622,7 +4627,7 @@ download_from_repo() {
 	    err 1 "null mount failed for pkg cache"
 	if ! JNETNAME="n" injail xargs \
 	    env ASSUME_ALWAYS_YES=yes \
-	    ${pkg_bin} fetch -U -r FreeBSD < "${wantedpkgs}"; then
+	    ${pkg_bin} fetch -U -r ${repo_name} < "${wantedpkgs}"; then
 		msg "Package fetch: Error fetching packages"
 		umountfs "${MASTERMNT:?}/var/cache/pkg"
 		rm -f "${wantedpkgs}"


### PR DESCRIPTION
- updates #1025

This supports a promotion workflow, where you have e.g. two different ports trees, dev and main. One can fetch from the other without having to rebuild all of the common packages.

```sh
poudriere bulk -j 143 -p dev -C sysutils/quickjail # always builds
poudriere bulk -j 143 -p main -C -b https://mypkgrepo.dev/pkg/143-dev/ sysutils/quickjail # fetches
```

The only commit that's actually necessary to support this is d87adf0c16a485b67d2c36aa07a75d697ce72f58, because it will simply configure the FreeBSD repo to not do all the other verification. However, by disabling the FreeBSD repo and setting the name to `custom`, it simplifies the config a bit.

Note that this includes the commit from #1228 so that this PR can work on 14.3 which ships with FreeBSD and FreeBSD-kmod configured.