### PR TITLE
Add overlays to the jail command

### DIFF
--- a/src/man/poudriere-jail.8
+++ b/src/man/poudriere-jail.8
@@ -28,7 +28,7 @@
 .\"
 .\" Note: The date here should be updated whenever a non-trivial
 .\" change is made to the manual page.
-.Dd April 19, 2024
+.Dd August 11, 2025
 .Dt POUDRIERE-JAIL 8
 .Os
 .Sh NAME
@@ -47,6 +47,7 @@
 .Op Fl m Ar method
 .Op Fl P Ar patch
 .Op Fl p Ar portstree
+.Op Fl O Ar overlay Op Fl O Ar overlay2 Ar ...
 .Op Fl S Ar srcpath
 .Op Fl z Ar set
 .Nm
@@ -336,6 +337,13 @@ to the source tree before building the jail.
 .It Fl p Ar portstree
 Specify the ports tree to start/stop the jail with.
 .Pq Default: Dq Li default
+.It Fl O Ar overlay
+Specify an extra
+.Xr poudriere-ports 8
+tree to use as an overlay.
+Multiple
+.Fl O Ar overlay
+arguments may be specified to stack them.
 .It Fl q
 Remove the header when
 .Fl l

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -85,6 +85,7 @@ Options for -d:
 
 Options for -s and -k:
     -p tree       -- Specify which ports tree to start/stop the jail with.
+    -O overlays   -- Specify extra ports trees to overlay.
     -z set        -- Specify which SET the jail to start/stop with.
 EOF
 	exit ${EX_USAGE}
@@ -1232,6 +1233,7 @@ REALARCH=${ARCH}
 QUIET=0
 NAMEONLY=0
 PTNAME=default
+OVERLAYS=""
 SETNAME=""
 XDEV=1
 BUILD=0
@@ -1243,7 +1245,7 @@ set_command() {
 	COMMAND="$1"
 }
 
-while getopts "bBiJ:j:v:a:z:m:nf:M:sdkK:lqcip:r:uU:t:z:P:S:DxXC:y" FLAG; do
+while getopts "bBiJ:j:v:a:z:m:nf:M:sdkK:lqcip:O:r:uU:t:z:P:S:DxXC:y" FLAG; do
 	case "${FLAG}" in
 		b)
 			BUILD=1
@@ -1316,6 +1318,11 @@ while getopts "bBiJ:j:v:a:z:m:nf:M:sdkK:lqcip:r:uU:t:z:P:S:DxXC:y" FLAG; do
 				OPTARG="${SAVED_PWD}/${OPTARG}"
 			fi
 			SRCPATCHFILE="${OPTARG}"
+			;;
+		O)
+			porttree_exists ${OPTARG} ||
+			    err 2 "No such overlay ${OPTARG}"
+			OVERLAYS="${OVERLAYS} ${OPTARG}"
 			;;
 		S)
 			[ -d ${OPTARG} ] || err 1 "No such directory ${OPTARG}"


### PR DESCRIPTION
I think there is a missing option for running a reference jail when working with overlays.
We have all the required utilities. We just need to pass the information about the overlays.