### PR TITLE
jail: ensure ALPHA builds are picked up from /releases/ url

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -833,7 +833,7 @@ install_from_ftp() {
 		case ${METHOD} in
 			ftp|http|gjb)
 				case ${VERSION} in
-					*-CURRENT|*-ALPHA*|*-PRERELEASE|*-STABLE) type=snapshots ;;
+					*-CURRENT|*-PRERELEASE|*-STABLE) type=snapshots ;;
 					*) type=releases ;;
 				esac
 


### PR DESCRIPTION
The alpha builds are published at /releases/ not /snapshots/ so
the fetch fails as it believes ALPHA should be in snapshots.

e.g. https://download.freebsd.org/ftp/releases/arm64/15.0-ALPHA1/