### PR TITLE
image: Skip pkg lines beginning with a comment

### DIFF
--- a/src/share/poudriere/awk/unique_pkgnames_from_flavored_origins.awk
+++ b/src/share/poudriere/awk/unique_pkgnames_from_flavored_origins.awk
@@ -27,7 +27,8 @@ $1 == "flavor" {
 }
 END {
 	while ((getline origin < pkglist) > 0) {
-		if (pkgname[origin])
+		if (origin ~ /^#/) continue
+		else if (pkgname[origin])
 			print pkgname[origin]
 		else
 			print origin


### PR DESCRIPTION
Image creation fails when a list of pkg includes commented out lines.

@bdrewery I am not sure the best way to do this in awk or even if this is the best place, but this works for me..