### PR TITLE
poudriere-image: optionally set zpool compatibility flags at creation

### DIFF
--- a/src/man/poudriere-image.8
+++ b/src/man/poudriere-image.8
@@ -75,6 +75,10 @@ be populated by the script.
 .It Fl c Ar overlaydir
 This specifies an extra directory whose contents will be copied directly into
 the final image, starting from the root.
+.It Fl C Ar compatibility
+This specifies the ZFS pool compatibility string to use when creating ZFS pools.
+The compatibility string controls which ZFS features are enabled.
+Only applies to ZFS-based image types.
 .It Fl f Ar packagelist
 This specifies a list of packages to be pre-installed in the final image.
 .It Fl h Ar hostname

--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -60,6 +60,7 @@ Options:
     -c overlaydir   -- The content of the overlay directory will be copied into
                        the image. Owners and permissions will be overwritten if
                        an <overlaydir>.mtree file is found
+    -C compatibility -- ZFS pool compatibility string for ZFS-based image types
     -f packagelist  -- List of packages to install
     -h hostname     -- The image hostname
     -i originimage  -- Origin image name
@@ -278,7 +279,7 @@ PKG_QUIET="-q"
 : ${PRE_BUILD_SCRIPT:=""}
 : ${POST_BUILD_SCRIPT:=""}
 
-while getopts "A:bB:c:f:h:i:j:m:n:o:p:P:R:s:S:t:vw:X:z:" FLAG; do
+while getopts "A:bB:c:C:f:h:i:j:m:n:o:p:P:R:s:S:t:vw:X:z:" FLAG; do
 	case "${FLAG}" in
 		A)
 			[ "${OPTARG#/}" = "${OPTARG}" ] && \
@@ -300,6 +301,9 @@ while getopts "A:bB:c:f:h:i:j:m:n:o:p:P:R:s:S:t:vw:X:z:" FLAG; do
 			    OPTARG="${SAVED_PWD}/${OPTARG}"
 			[ -d "${OPTARG}" ] || err 1 "No such extract directory: ${OPTARG}"
 			EXTRADIR=$(realpath "${OPTARG}")
+			;;
+		C)
+			ZFS_COMPATIBILITY="${OPTARG}"
 			;;
 		f)
 			# If this is a relative path, add in ${PWD} as

--- a/src/share/poudriere/image_rawdisk.sh
+++ b/src/share/poudriere/image_rawdisk.sh
@@ -74,10 +74,16 @@ zrawdisk_prepare()
 	truncate -s ${IMAGESIZE} ${WRKDIR}/raw.img
 	md=$(/sbin/mdconfig ${WRKDIR}/raw.img)
 	zroot=${IMAGENAME}root
+	if [ -n "${ZFS_COMPATIBILITY}" ]; then
+		compatibility_opt="-o compatibility=${ZFS_COMPATIBILITY}"
+	else
+		compatibility_opt=""
+	fi
 	zpool create \
 		-O mountpoint=none \
 		-O compression=lz4 \
 		-O atime=off \
+		${compatibility_opt} \
 		-R ${WRKDIR}/world ${zroot} /dev/${md}
 	zfs create -o mountpoint=none ${zroot}/ROOT
 	zfs create -o mountpoint=/ ${zroot}/ROOT/default

--- a/src/share/poudriere/image_zfs.sh
+++ b/src/share/poudriere/image_zfs.sh
@@ -64,12 +64,18 @@ zfs_prepare()
 	md=$(/sbin/mdconfig ${WRKDIR}/raw.img)
 
 	msg "Creating temporary ZFS pool"
+	if [ -n "${ZFS_COMPATIBILITY}" ]; then
+		compatibility_opt="-o compatibility=${ZFS_COMPATIBILITY}"
+	else
+		compatibility_opt=""
+	fi
 	zpool create \
 		-O mountpoint=/${ZFS_POOL_NAME} \
 		-O canmount=noauto \
 		-O checksum=on \
 		-O compression=on \
 		-O atime=off \
+		${compatibility_opt} \
 		-t ${zroot} \
 		-R ${WRKDIR}/world ${ZFS_POOL_NAME} /dev/${md} || exit
 


### PR DESCRIPTION
Running `poudriere image -t zfs ...` on more modern versions of FreeBSD than the targeted release will make zpools that cannot be booted successfully, due to zpool options that the boot loader and zfs kernel module cannot handle.

`zpool-create(8)` supports compatibility flags, typically listed in `/usr/share/zfs/compatibility.d/`. At time of writing, `freebsd-13.2` is the latest FreeBSD-specific tag.