### PR TITLE
common/update_version_env(): don't set both ABI_FILE and OSVERSION

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -3465,11 +3465,13 @@ update_version_env() {
 	local osversion="$5"
 	local login_env
 
-	login_env=",UNAME_r=${version% *},UNAME_v=FreeBSD ${version},OSVERSION=${osversion}"
+	login_env=",UNAME_r=${version% *},UNAME_v=FreeBSD ${version}"
 
 	# Tell pkg(8) to not use /bin/sh for the ELF ABI since it is native.
 	if [ "${QEMU_EMULATING}" -eq 1 ]; then
 		login_env="${login_env},ABI_FILE=\/usr\/lib\/crt1.o"
+	else
+		login_env="${login_env},OSVERSION=${osversion}"
 	fi
 
 	# Check TARGET=i386 not TARGET_ARCH due to pc98/i386


### PR DESCRIPTION
This fixes an annoying message that shows up for every built port when building with QEMU:

"pkg-static: Both ABI_FILE and OSVERSION are set, ABI_FILE overrides OSVERSION"