### PR TITLE
Fix fetching packages on FreeBSD 15.0

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2776,11 +2776,26 @@ enter_interactive() {
 	msg "Installing local Pkg repository to ${LOCALBASE}/etc/pkg/repos"
 	mkdir -p ${MASTERMNT:?}${LOCALBASE:?}/etc/pkg/repos
 	cat > ${MASTERMNT:?}${LOCALBASE:?}/etc/pkg/repos/local.conf <<-EOF
-	FreeBSD: { enabled: no }
-	FreeBSD-kmods: { enabled: no }
-	FreeBSD-ports: { enabled: no }
-	FreeBSD-ports-kmods: { enabled: no }
-	FreeBSD-base: { enabled: no }
+	FreeBSD: {
+		enabled: no,
+		priority: 100
+	}
+	FreeBSD-kmods: {
+		enabled: no,
+		priority: 100
+	}
+	FreeBSD-ports: {
+		enabled: no,
+		priority: 100
+	}
+	FreeBSD-ports-kmods: {
+		enabled: no,
+		priority: 100
+	}
+	FreeBSD-base: {
+		enabled: no,
+		priority: 100
+	}
 
 	local: {
 		url: "file:///packages",
@@ -4688,15 +4703,30 @@ download_from_repo() {
 		pkg_bin="pkg"
 	fi
 	cat >> "${MASTERMNT:?}/etc/pkg/poudriere.conf" <<-EOF
-	FreeBSD: { enabled: no }
-	FreeBSD-kmods: { enabled: no }
-	FreeBSD-ports: { enabled: no }
-	FreeBSD-ports-kmods: { enabled: no }
-	FreeBSD-base: { enabled: no }
+	FreeBSD: {
+		enabled: no,
+		priority: 100
+	}
+	FreeBSD-kmods: {
+		enabled: no,
+		priority: 100
+	}
+	FreeBSD-ports: {
+		enabled: no,
+		priority: 100
+	}
+	FreeBSD-ports-kmods: {
+		enabled: no,
+		priority: 100
+	}
+	FreeBSD-base: {
+		enabled: no,
+		priority: 100
+	}
 
 	Poudriere: {
-	        url: ${packagesite};
-	        mirror_type: $(if [ "${packagesite#pkg+}" = "${packagesite}" ]; then echo "none"; else echo "srv"; fi);
+		url: ${packagesite},
+		mirror_type: $(if [ "${packagesite#pkg+}" = "${packagesite}" ]; then echo "none"; else echo "srv"; fi)
 	}
 	EOF
 

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -926,11 +926,26 @@ pkgbase: {
 }
 EOF
 	cat <<EOF > "${JAILMNT}/etc/pkg/FreeBSD2.conf"
-FreeBSD: { enabled: no }
-FreeBSD-kmods: { enabled: no }
-FreeBSD-ports: { enabled: no }
-FreeBSD-ports-kmods: { enabled: no }
-FreeBSD-base: { enabled: no }
+FreeBSD: {
+	enabled: no,
+	priority: 100
+}
+FreeBSD-kmods: {
+	enabled: no,
+	priority: 100
+}
+FreeBSD-ports: {
+	enabled: no,
+	priority: 100
+}
+FreeBSD-ports-kmods: {
+	enabled: no,
+	priority: 100
+}
+FreeBSD-base: {
+	enabled: no,
+	priority: 100
+}
 EOF
 
 	pkg -o IGNORE_OSVERSION=yes -o REPOS_DIR="${JAILMNT}/etc/pkg" -o ABI="FreeBSD:${VERSION}:${ARCH}" -r ${JAILMNT}/ update


### PR DESCRIPTION
Older versions of FreeBSD had a single package repository, named "FreeBSD".  FreeBSD 14.3 introduced a second repository for kernel modules, named "FreeBSD-kmods".  FreeBSD 15.0 add support for managing the base system with packages (aka pkgbase), and to avoid confusion for
users and emphasis they are related to ports and not the base system, the mentioned repositories were respectively renamed "FreeBSD-ports" and "FreeBSD-ports-kmods".

In order to fetch latest packages, poudriere tune the "FreeBSD" repo, and attempts were made to ignore the "FreeBSD-kmods" repository (#1218, #1228), unfortunately with the changes described above in FreeBSD 15, it is broken again.

Since fa68587c67ffb59c1c240d53fb16e73788d06cd3, poudriere disable all official repositories, but that was not done for fetching packages.

Fix this by disabling all known variations of the default FreeBSD repositories there too, and setup a single "Poudriere" repository configured to our wills.

This will allow us to have full control of that repository without being impacted by changes on the FreeBSD side.

Fixes #1227
Fixes #1238