### PR TITLE
Misc horizontal and vertical alignments fixes

### DIFF
--- a/src/share/poudriere/html/assets/poudriere.js
+++ b/src/share/poudriere/html/assets/poudriere.js
@@ -1002,8 +1002,8 @@ function do_resize(win) {
   }
   /* Resize padding for navbar/footer heights */
   $("body")
-    .css("padding-top", $("#header").outerHeight(true))
-    .css("padding-bottom", $("footer").outerHeight(true));
+    .css("padding-top", $("nav.navbar.fixed-top").outerHeight(true))
+    .css("padding-bottom", $("nav.navbar.fixed-bottom").outerHeight(true));
 }
 
 /* Force minimum width on mobile, will zoom to fit. */

--- a/src/share/poudriere/html/build.html
+++ b/src/share/poudriere/html/build.html
@@ -45,7 +45,7 @@
 
     <link rel="icon" type="image/png" href="assets/favicon.png" />
   </head>
-  <body class="p-0">
+  <body>
     <div id="top"></div>
     <nav
       class="navbar navbar-expand-lg bg-dark fixed-top p-3"
@@ -167,8 +167,8 @@
       </div>
     </nav>
     <!-- navbar -->
-    <section id="section-build" class="p-5">
-      <div id="main" class="container p-5">
+    <section id="section-build">
+      <div id="main" class="container">
         <div class="row">
           <div class="col-md-5">
             <div id="build_info_div" style="display: none">

--- a/src/share/poudriere/html/index.html
+++ b/src/share/poudriere/html/index.html
@@ -47,7 +47,7 @@
 
     <link rel="icon" type="image/png" href="assets/favicon.png" />
   </head>
-  <body class="p-0">
+  <body>
     <div id="top"></div>
     <nav
       class="navbar navbar-expand-lg bg-dark fixed-top p-3"
@@ -112,8 +112,8 @@
       <!-- /container -->
     </nav>
     <!-- navbar -->
-    <section id="section" class="p-5">
-      <div id="main" class="container p-5">
+    <section id="section">
+      <div id="main" class="container">
         <div id="loading_overlay">
           <div id="loading">
             <p>Loading...</p>

--- a/src/share/poudriere/html/jail.html
+++ b/src/share/poudriere/html/jail.html
@@ -46,7 +46,7 @@
 
     <link rel="icon" type="image/png" href="assets/favicon.png" />
   </head>
-  <body class="p-0">
+  <body>
     <div id="top"></div>
     <nav
       class="navbar navbar-expand-lg bg-dark fixed-top p-3"
@@ -119,8 +119,8 @@
       <!-- /container -->
     </nav>
     <!-- navbar -->
-    <section id="section" class="p-5">
-      <div id="main" class="container p-5">
+    <section id="section">
+      <div id="main" class="container">
         <div id="loading_overlay">
           <div id="loading">
             <p>Loading...</p>


### PR DESCRIPTION
The HTML pages have dubious `p-[0-9]` CSS classes, and some JS code
supposed to add proper padding on the top and bottom of the body
reference incorrect elements (probably from an older version of the
code).  Combined, this result in unaligned items horizontally, and
unexpected spacing vertically.

Remove these extra CSS classes, and fix the items used to adjust body
padding.
