### PR TITLE
Add '--always' to git describe command line

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -377,7 +377,7 @@ poudriere: src/bin/poudriere.in
 	$(AM_V_GEN)if test -e $(top_srcdir)/.git && \
 	    which git >/dev/null 2>&1 && \
 	    [ -d "$$(git -C "$(top_srcdir)" rev-parse --git-dir)" ]; then \
-	    gitver=$$(git -C "$(top_srcdir)" describe --tags HEAD); \
+	    gitver=$$(git -C "$(top_srcdir)" describe --always --tags HEAD); \
 	    sed \
 	      -e "s,^\(POUDRIERE_VERSION\)=.*,\1='$${gitver}'," \
 	      -e "s,^\(USE_DEBUG\)=.*,\1='@USE_DEBUG@'," \

--- a/Makefile.in
+++ b/Makefile.in
@@ -3693,7 +3693,7 @@ poudriere: src/bin/poudriere.in
 	$(AM_V_GEN)if test -e $(top_srcdir)/.git && \
 	    which git >/dev/null 2>&1 && \
 	    [ -d "$$(git -C "$(top_srcdir)" rev-parse --git-dir)" ]; then \
-	    gitver=$$(git -C "$(top_srcdir)" describe --tags HEAD); \
+	    gitver=$$(git -C "$(top_srcdir)" describe --always --tags HEAD); \
 	    sed \
 	      -e "s,^\(POUDRIERE_VERSION\)=.*,\1='$${gitver}'," \
 	      -e "s,^\(USE_DEBUG\)=.*,\1='@USE_DEBUG@'," \


### PR DESCRIPTION
If I fork the poudriere repo, by default there won't be any tags created in my copy.  This causes `git describe` to be unhappy and breaks compilation:

```
% git -C . describe --tags HEAD
fatal: No names found, cannot describe anything.
```

Add the `--always` flag so `git describe` will fake a tag based on the short hash of HEAD if no tags exist:

```
% git -C . describe --always --tags HEAD
509e6e0e
```