### PR TITLE
Pass VERBOSE to hooks

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -1241,6 +1241,7 @@ run_hook_file() {
 		    SETNAME="${SETNAME-}" \
 		    PACKAGES="${PACKAGES-}" \
 		    PACKAGES_ROOT="${PACKAGES_ROOT-}" \
+		    VERBOSE="${VERBOSE:-0}" \
 		    /bin/sh "${hookfile:?}" "${event}" "$@"
 	) || err 1 "Hook ${hookfile} for '${hook}:${event}' returned non-zero"
 	return 0


### PR DESCRIPTION
Allow hooks to log output based on the requested verbose level (-v/-vv).