### PR TITLE
Fix issue OSVERSION is empty with pkgbase jail

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -117,8 +117,8 @@ list_jail() {
 			_jget method ${name} method
 			_jget mnt ${name} mnt
 			_jget timestamp ${name} timestamp || :
-			if [ -r "${mnt}/sys/sys/param.h" ]; then
-				osversion=$(awk '/^\#define[[:blank:]]__FreeBSD_version/ {print $3}' "${mnt}/sys/sys/param.h")
+			if [ -r "${mnt}/usr/include/sys/param.h" ]; then
+				osversion=$(awk '/^\#define[[:blank:]]__FreeBSD_version/ {print $3}' "${mnt}/usr/include/sys/param.h")
 			else
 				osversion=
 			fi


### PR DESCRIPTION
If jail is created with pkgbase method, there isn't `/sys` symlink in it.

This fixes #1292.