### PR TITLE
Do not run make in jails without src

### DIFF
--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -268,7 +268,9 @@ install_world()
 	[ ! -f ${POUDRIERED}/${JAILNAME}-src.conf ] || cat ${POUDRIERED}/${JAILNAME}-src.conf >> ${WRKDIR:?}/src.conf
 	[ ! -f ${POUDRIERED}/image-${JAILNAME}-src.conf ] || cat ${POUDRIERED}/image-${JAILNAME}-src.conf >> ${WRKDIR:?}/src.conf
 	[ ! -f ${POUDRIERED}/image-${JAILNAME}-${SETNAME}-src.conf ] || cat ${POUDRIERED}/image-${JAILNAME}-${SETNAME}-src.conf >> ${WRKDIR:?}/src.conf
-	make -s -C ${mnt:?}/usr/src DESTDIR=${WRKDIR:?}/world BATCH_DELETE_OLD_FILES=yes SRCCONF=${WRKDIR:?}/src.conf delete-old delete-old-libs
+	if [ -f ${mnt:?}/usr/src/Makefile ]; then
+	    make -s -C ${mnt:?}/usr/src DESTDIR=${WRKDIR:?}/world BATCH_DELETE_OLD_FILES=yes SRCCONF=${WRKDIR:?}/src.conf delete-old delete-old-libs
+	fi
 	msg "Installing world done"
 }
 


### PR DESCRIPTION
install_world() calls `make delete-old delete-old-libs`, but a jail created with upstream pkgbase does not have src and so the command fails. pkg removes any unneeded files, so there's no need to delete-old on upstream pkgbase jails.

Signed-off-by: Pat Maddox <pat@patmaddox.com>

Change-Id: Ic11f82d89e6059032138fb73ccb2b2ad6a6a6964