### PR TITLE
logclean: Fix empty build log directory removal with multiple jails

### DIFF
--- a/src/share/poudriere/logclean.sh
+++ b/src/share/poudriere/logclean.sh
@@ -398,7 +398,7 @@ if [ ${logs_deleted} -eq 1 ]; then
 	if lock_have "logs_latest-per-pkg"; then
 		case "${MASTERNAMES_LOCKED:+set}" in
 		set)
-			echo "${MASTERNAMES_LOCKED:?}" | sed -e 's,$,/latest-per-pkg,' | \
+			echo "${MASTERNAMES_LOCKED:?}" | tr ' ' '\n' | sed -e 's,$,/latest-per-pkg,' | \
 			    tr '\n' '\000' | \
 			    xargs -0 -J % find -x % -mindepth 0 -maxdepth 0 -empty | \
 			    sed -e 's,$,/..,' | xargs realpath | tr '\n' '\000' | \


### PR DESCRIPTION
When multiple jails are configured, the "Removing empty build log directories" step fails because the script incorrectly processes the space-separated MASTERNAMES_LOCKED list.

The issue is that sed appends "/latest-per-pkg" to the end of the entire space-separated string rather than to each jail name individually. This results in a malformed path like:
  "neptune-amd64-default odin-amd64-default saturn-amd64-default/latest-per-pkg"

Fix by converting spaces to newlines before the sed operation, ensuring each jail name gets the suffix appended correctly.

Fixes #1157