### PR TITLE
Fix "bulk -b"'s pkg version check with certain package servers

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -4806,7 +4806,7 @@ download_from_repo() {
 		return 0
 	fi
 
-	remote_pkg_ver="$(injail ${pkg_bin} rquery -U %v "${P_PKG_PKGBASE:?}")"
+	remote_pkg_ver="$(injail ${pkg_bin} rquery -U -r "${PACKAGE_FETCH_BRANCH}" %v "${P_PKG_PKGBASE:?}")"
 	local_pkg_name="${P_PKG_PKGNAME:?}"
 	local_pkg_ver="${local_pkg_name##*-}"
 	case "$(pkg_version -t "${remote_pkg_ver}" "${local_pkg_ver}")" in


### PR DESCRIPTION
When using "bulk -b" or "testport -b", Poudriere will check that the remote server's pkg version is less than or equal to the local package version before fetching any remote packages.  That process entails running "pkg rquery -U" from within the build jail.  But in some setups pkg-rquery will return two results: one for the remote server and one for the local package cache.  That screws up the shell script's parsing of the output.  I don't know why this doesn't happen to everybody, but the solution is simple: use rquery's "-r" option.

Sponsored by:	ConnectWise