### PR TITLE
rquery: fix usage to be compatible with all pkg versions

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -4821,17 +4821,17 @@ download_from_repo() {
 	# (like pkg rquery -U), and it uses various locking that isn't needed
 	# here. Grab all the options for comparison.
 	remote_all_options=$(mktemp -t remote_all_options)
-	injail ${pkg_bin} rquery -U '%n %Ok %Ov' > "${remote_all_options}"
+	injail ${pkg_bin} rquery -U -e '%#O > 0' '%n %Ok %Ov' > "${remote_all_options}"
 	remote_all_pkgs=$(mktemp -t remote_all_pkgs)
 	injail ${pkg_bin} rquery -U '%n %n-%v %?O' > "${remote_all_pkgs}"
 	remote_all_deps=$(mktemp -t remote_all_deps)
-	injail ${pkg_bin} rquery -U '%n %dn-%dv' > "${remote_all_deps}"
+	injail ${pkg_bin} rquery -U -e '%#d > 0' '%n %dn-%dv' > "${remote_all_deps}"
 	remote_all_annotations=$(mktemp -t remote_all_annotations)
 	remote_all_cats=$(mktemp -t remote_all_cats)
 	case "${IGNORE_OSVERSION-}" in
 	"yes") ;;
 	*)
-		injail ${pkg_bin} rquery -U '%n %At %Av' > "${remote_all_annotations}"
+		injail ${pkg_bin} rquery -U -e '%#A' '%n %At %Av' > "${remote_all_annotations}"
 		injail ${pkg_bin} rquery -U '%n %C' > "${remote_all_cats}"
 		;;
 	esac


### PR DESCRIPTION
sorry I haven't see the rquery bug was used in poudriere, this should fix the usage