### PR TITLE
testport: do not check the parent directory of a port does not have Mk

### DIFF
--- a/src/share/poudriere/testport.sh
+++ b/src/share/poudriere/testport.sh
@@ -276,8 +276,7 @@ testport_post_gather_port_vars() {
 	# Ensure the port exists after handling MOVED.
 	_lookup_portdir portdir "${ORIGIN}"
 	if [ "${portdir:?}" = "${PORTSDIR:?}/${ORIGIN:?}" ] &&
-		[ ! -f "${portsdir:?}/${ORIGIN:?}/Makefile" ] ||
-		[ -d "${portsdir:?}/${ORIGIN:?}/../Mk" ]; then
+		[ ! -f "${portsdir:?}/${ORIGIN:?}/Makefile" ]; then
 		err 1 "Nonexistent origin ${COLOR_PORT}${ORIGIN}${COLOR_RESET}"
 	fi
 	get_pkgname_from_originspec "${ORIGINSPEC:?}" PKGNAME ||


### PR DESCRIPTION
The check originates from d72e70f and is not a comprehensive check that directory is a valid port directory anyway.  But it breaks a custom port tree (built on top of FreeBSD ports) that has some internal Mk directories.

Fixes: #1319