### PR TITLE
fix: correct typos in comments and man pages

### DIFF
--- a/src/man/poudriere-image.8
+++ b/src/man/poudriere-image.8
@@ -125,7 +125,7 @@ This specifies the maximum size of the image that is built.
 This specifies the type of image to create:
 .Bl -tag -width "rawfirmware"
 .It hybridiso
-An ISO 9660 format image that that is also a valid GPT image and can be written
+An ISO 9660 format image that is also a valid GPT image and can be written
 to a USB device for BIOS/legacy and UEFI boot.
 .It iso
 An ISO 9660 format image.

--- a/src/man/poudriere-status.8
+++ b/src/man/poudriere-status.8
@@ -39,7 +39,7 @@
 .Op Ar options
 .Sh DESCRIPTION
 This command shows status of current and previous builds.
-The output is sorted by by SETNAME, PORTSTREE, JAILNAME and then BUILDNAME.
+The output is sorted by SETNAME, PORTSTREE, JAILNAME and then BUILDNAME.
 .Sh OPTIONS
 .Bl -tag -width "-f conffile"
 .It Fl a

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -9259,7 +9259,7 @@ gather_port_vars_process_depqueue() {
 }
 
 # We may gather metadata for more ports than we actually want to build.
-# In here will will compute the list of packages that we are actually
+# In here we will compute the list of packages that we are actually
 # interested in.
 compute_needed() {
 	[ "$#" -eq 0 ] || eargs compute_needed

--- a/src/share/poudriere/include/pkgqueue.sh
+++ b/src/share/poudriere/include/pkgqueue.sh
@@ -474,7 +474,7 @@ _pkgqueue_clean_queue() {
 	_pkgqueue_clean_rdeps "${pkgqueue_job}" "${clean_rdepends}" || ret="$?"
 
 	# Remove this pkg from the needs-to-build list. It will not exist
-	# if this build was sucessful. It only exists if pkgqueue_clean_queue is
+	# if this build was successful. It only exists if pkgqueue_clean_queue is
 	# being called recursively to skip items and in that case it will
 	# not be empty.
 	case "${clean_rdepends:+set}" in


### PR DESCRIPTION
Fix a handful of small typos found across comments and man pages

- `sucessful` → `successful` in pkgqueue.sh
- Duplicate word `that that` in poudriere-image.8
- Duplicate word `by by` in poudriere-status.8
- `will will` → `we will` in common.sh