### PR TITLE
jail: add a pkbase example, and fix version usage.

### DIFF
--- a/src/man/poudriere-jail.8
+++ b/src/man/poudriere-jail.8
@@ -458,6 +458,15 @@ already exists.
 .Bd -literal -offset 2n
 .Li # Ic poudriere jail -l -n -q | grep --quiet '^130i386$'
 .Ed
+.It Sy Example 3\&: No Creating a Jail using base system packages
+.Pp
+The following example creates a new jail called
+.Dq 151amd64
+from the official base system packages repository for
+.Fx 15.1-RELEASE .
+.Bd -literal -offset 2n
+.Li # Ic poudriere jail -c -j 151amd64 -v 15.1-RELEASE -m pkgbase=base_release_1 -U https://pkg.freebsd.org/
+.Ed
 .El
 .Sh SEE ALSO
 .Xr jail 8 ,

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -1004,6 +1004,7 @@ install_from_tar() {
 
 install_from_pkgbase() {
 	msg_n "Installing ${VERSION} ${ARCH} from ${SOURCES_URL} ..."
+	VERSION="${VERSION%%.*}"
 	mkdir -p "${JAILMNT}/etc/pkg"
 	cat <<EOF > "${JAILMNT}/etc/pkg/pkgbase.conf"
 pkgbase: {


### PR DESCRIPTION
When using base system package installs, and following manpage `-v version` syntax, the version parsing isn't correct, and it's not possible to install base system package jails as a result:

```
# poudriere jail -c -j 151amd64 -v 15.1-BETA3 \
    -m pkgbase=base_release_1 \
    -U https://pkg.freebsd.org/
[00:00:00] Creating 151amd64 fs at /usr/local/poudriere/jails/151amd64... done
[00:00:00] Installing 15.1-BETA3 amd64 from https://pkg.freebsd.org/ ...
  pkg: Invalid version in ABI string 'FreeBSD:15.1-BETA3:amd64' <-----------------
pkg: Cannot parse configuration file!
[00:00:00] Error: /usr/local/share/poudriere/jail.sh:install_from_pkgbase:35:pkg update failed
[00:00:00] Error while creating jail, cleaning up.
[00:00:00] Removing 151amd64 jail... done
```

This does work, but it's not obvious:

```
# poudriere jail -c -j 151amd64 -v 15 ...
```

So add a pkg base example, and truncate `-v VERSION` in future.