### PR TITLE
jail: explicitly fail if FreeBSD-src-sys can't be installed

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -1039,7 +1039,8 @@ EOF
 	    err 1 "pkg update failed"
 	# Omit the man/debug/kernel/src and tests packages, unneeded for us.
 	pkg -o IGNORE_OSVERSION=yes -o REPOS_DIR="${JAILMNT}/etc/pkg" -o ABI="FreeBSD:${VERSION}:${ARCH#*.}" -r ${JAILMNT}/ search -qCx '^FreeBSD-.*' | grep -vE -- '-man|-dbg|-kernel-|-tests|-src-' | xargs pkg -o REPOS_DIR="${JAILMNT}/etc/pkg" -r ${JAILMNT}/ install -y
-	pkg -o IGNORE_OSVERSION=yes -o REPOS_DIR="${JAILMNT}/etc/pkg" -o ABI="FreeBSD:${VERSION}:${ARCH#*.}" -r ${JAILMNT}/ search -q '^FreeBSD-src-sys' | xargs pkg -o REPOS_DIR="${JAILMNT}/etc/pkg" -r ${JAILMNT}/ install -y
+	pkg -o IGNORE_OSVERSION=yes -o REPOS_DIR="${JAILMNT}/etc/pkg" -o ABI="FreeBSD:${VERSION}:${ARCH#*.}" -r ${JAILMNT}/ install -y FreeBSD-src-sys || \
+	    err 1 "Failed to install FreeBSD-src-sys (needed for sys/param.h)"
 	if [ -n "${KERNEL}" ]; then
 		pkg -o IGNORE_OSVERSION=yes -o REPOS_DIR="${JAILMNT}/etc/pkg" -o ABI="FreeBSD:${VERSION}:${ARCH#*.}" -r ${JAILMNT}/ install -y FreeBSD-kernel-"${KERNEL}" || \
 			err 1 "Failed to install FreeBSD-kernel-${KERNEL}"


### PR DESCRIPTION
I'm not sure of the purpose of the intricate previous code:

```
pkg -o IGNORE_OSVERSION=yes -o REPOS_DIR="${JAILMNT}/etc/pkg" -o ABI="FreeBSD:${VERSION}:${ARCH#*.}" -r ${JAILMNT}/ search -q '^FreeBSD-src-sys' \
| xargs pkg -o REPOS_DIR="${JAILMNT}/etc/pkg" -r ${JAILMNT}/ install -y
```

But if the repo URL is incorrect, (e.g. points to a path that doesn't have packages) then this fails silently, and you end up with a poudriere jail without FreeBSD-src-sys.

Now it will fail loudly:

```# poudriere jail -c -j bad_pkgbase -v 16 -m pkgbase=latest -U https://pkg.freebsd.org/
[00:00:00] Creating bad_pkgbase fs at /usr/local/poudriere/jails/bad_pkgbase... done
[00:00:00] Installing 16 amd64 from https://pkg.freebsd.org/ ...pkg: Setting ABI requires setting OSVERSION, guessing the OSVERSION as: 1600000
Updating pkgbase repository catalogue...
Fetching meta.conf: 100%     179 B   0.2 kB/s    00:01
Fetching data: 100%    11 MiB   2.8 MB/s    00:04
Processing entries: 100%
pkgbase repository update completed. 36598 packages processed.
All repositories are up to date.
pkg: Setting ABI requires setting OSVERSION, guessing the OSVERSION as: 1600000
pkg: Setting ABI requires setting OSVERSION, guessing the OSVERSION as: 1600000
Updating pkgbase repository catalogue...
pkgbase repository is up to date.
All repositories are up to date.
pkg: No packages available to install matching 'FreeBSD-src-sys' have been found in the repositories
[00:00:08] Error: [26556] /usr/local/share/poudriere/jail.sh:install_from_pkgbase:40:Failed to install FreeBSD-src-sys (needed for sys/param.h)
[00:00:08] Error while creating jail, cleaning up.
[00:00:08] Removing bad_pkgbase jail... done
Exiting with status 1
```

cc @jlduran @evadot who touched this area last

Are there circumstances where this silent failure is OK? Do we have vendors who build `MadRouterCo-src-sys` packages?

I would like to update the manpage to point to where these URLs are documented, but I only find the pkgbase wiki page.