### PR TITLE
build.html: update "Failed Ports" title bar to match others

### DIFF
--- a/src/share/poudriere/html/build.html
+++ b/src/share/poudriere/html/build.html
@@ -321,7 +321,9 @@
             </div>
             <!-- #built -->
             <div id="failed_div" class="status" style="display: none">
-              <h2 id="failed">Failed ports</h2>
+              <div class="card my-3 bg-dark text-white fs-5">
+                <div class="card-body fs-5">Failed Ports</div>
+              </div>
               <table class="table table-striped" id="failed_table">
                 <thead>
                   <tr>


### PR DESCRIPTION
When the new title bar style was introduced failed_div was left behind. This brings failed_div into line with the others.