### PR TITLE
Add option (-e) to bulk and testport to run port tests

### DIFF
--- a/src/man/poudriere-bulk.8
+++ b/src/man/poudriere-bulk.8
@@ -38,7 +38,7 @@
 .Nm
 .Fl a
 .Fl j Ar name
-.Op Fl CcFHIikNnRrSTtvw
+.Op Fl CceFHIikNnRrSTtvw
 .Op Fl B Ar name
 .Op Fl b Ar branch
 .Op Fl J Ar maxjobs Ns Op Cm \&: Ns Ar prebuildmaxjobs
@@ -48,7 +48,7 @@
 .Nm
 .Fl f Ar file Op Fl f Ar file2 Ar ...
 .Fl j Ar name
-.Op Fl CcFHIikNnRrSTtvw
+.Op Fl CceFHIikNnRrSTtvw
 .Op Fl B Ar name
 .Op Fl b Ar branch
 .Op Fl J Ar maxjobs Ns Op Cm \&: Ns Ar prebuildmaxjobs
@@ -57,7 +57,7 @@
 .Op Fl z Ar set
 .Nm
 .Fl j Ar name
-.Op Fl CcFHIikNnRrSTtvw
+.Op Fl CceFHIikNnRrSTtvw
 .Op Fl B Ar name
 .Op Fl b Ar branch
 .Op Fl J Ar maxjobs Ns Op Cm \&: Ns Ar prebuildmaxjobs
@@ -226,6 +226,14 @@ for
 Clean
 .Em all
 previously built packages and logs.
+.It Fl e
+Run
+.Cm make test
+for each port after the build and stage phases complete.
+This helps catch missing
+.Va TEST_DEPENDS
+by running port tests in a clean environment where only declared
+dependencies are installed.
 .It Fl F
 Fetch only from the original
 .Va MASTER_SITES .

--- a/src/man/poudriere-testport.8
+++ b/src/man/poudriere-testport.8
@@ -90,6 +90,14 @@ See
 for further details.
 .It Fl c
 Run make config for the given port.
+.It Fl e
+Run
+.Cm make test
+after the build and stage phases complete.
+This helps catch missing
+.Va TEST_DEPENDS
+by running port tests in a clean environment where only declared
+dependencies are installed.
 .It Fl I
 Advanced Interactive mode.
 Leaves jail running with port installed after test.

--- a/src/share/poudriere/bulk.sh
+++ b/src/share/poudriere/bulk.sh
@@ -43,6 +43,10 @@ Options:
     -b branch   -- Branch to choose for fetching packages from official
                    repositories: valid options are: latest, quarterly,
                    release_*, or a url.
+    -e          -- Run 'make test' for each port after build and stage phases.
+                   This helps catch missing TEST_DEPENDS by running port tests
+                   in a clean environment where only declared dependencies are
+                   installed.
     -C          -- Clean only the packages listed on the command line or
                    -f file.  Implies -c for -a.
     -c          -- Clean all the previously built binary packages and logs.
@@ -98,12 +102,13 @@ BUILD_REPO=1
 INTERACTIVE_MODE=0
 OVERLAYS=""
 COMMIT=1
+PORT_RUN_TESTS=0
 
 if [ $# -eq 0 ]; then
 	usage
 fi
 
-while getopts "ab:B:CcFf:HiIj:J:knNO:p:RrSTtvwz:" FLAG; do
+while getopts "ab:B:CceFf:HiIj:J:knNO:p:RrSTtvwz:" FLAG; do
 	case "${FLAG}" in
 		a)
 			ALL=1
@@ -120,6 +125,9 @@ while getopts "ab:B:CcFf:HiIj:J:knNO:p:RrSTtvwz:" FLAG; do
 			;;
 		C)
 			CLEAN_LISTED=1
+			;;
+		e)
+			PORT_RUN_TESTS=1
 			;;
 		F)
 			export MASTER_SITE_BACKUP=''

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -5496,7 +5496,12 @@ build_port() {
 	# changes. Easier once pkg_install is EOL.
 	targets="check-sanity pkg-depends fetch-depends fetch checksum \
 		  extract-depends extract patch-depends patch build-depends \
-		  lib-depends configure build run-depends stage package"
+		  lib-depends configure build run-depends stage"
+	# Run port tests after staging when -e is specified.
+	if [ "${PORT_RUN_TESTS}" -eq 1 ]; then
+		targets="${targets} test-depends test"
+	fi
+	targets="${targets} package"
 	# Do a install/deinstall cycle for testport/bulk -t.
 	if [ "${PORTTESTING}" -eq 1 ]; then
 		targets="${targets} install deinstall"
@@ -5583,6 +5588,13 @@ build_port() {
 		checksum|*-depends) JUSER=root ;;
 		stage)
 			if [ "${PORTTESTING}" -eq 1 ]; then
+				markfs prestage "${mnt:?}"
+			fi
+			;;
+		test)
+			# Re-record prestage after test-depends has installed packages
+			# so check_fs_violation at package phase won't flag them.
+			if [ "${PORTTESTING}" -eq 1 -a "${PORT_RUN_TESTS}" -eq 1 ]; then
 				markfs prestage "${mnt:?}"
 			fi
 			;;
@@ -5701,7 +5713,15 @@ build_port() {
 					job_build_status "${phase}/timeout" \
 					    "${originspec}" "${pkgname}"
 				fi
-				return 1
+				if [ "${phase}" = "test" -a $hangstatus -eq 1 ]; then
+					msg "Error: Test failures detected"
+					if [ "${PORTTESTING_FATAL}" != "no" ]; then
+						return 1
+					fi
+					testfailure=2
+				else
+					return 1
+				fi
 			fi
 			;;
 		esac
@@ -11118,6 +11138,7 @@ esac
 : ${PORTTESTING:=0}
 : ${PORTTESTING_FATAL:=yes}
 : ${PORTTESTING_RECURSIVE:=0}
+: ${PORT_RUN_TESTS:=0}
 : ${PRIORITY_BOOST_VALUE:=99}
 : ${RESTRICT_NETWORKING:=yes}
 : ${DISALLOW_NETWORKING:=no}

--- a/src/share/poudriere/testport.sh
+++ b/src/share/poudriere/testport.sh
@@ -52,6 +52,10 @@ Options:
                    run a different number of jobs in parallel while preparing
                    the build. (Defaults to the number of CPUs for n and
                    1.25 times n for p)
+    -e          -- Run 'make test' after build and stage phases.
+                   This helps catch missing TEST_DEPENDS by running port tests
+                   in a clean environment where only declared dependencies are
+                   installed.
     -k          -- Don't consider failures as fatal; find all failures.
     -n          -- Dry-run. Show what will be done, but do not build
                    any packages.
@@ -83,8 +87,9 @@ BUILD_REPO=1
 OVERLAYS=""
 COMMIT=1
 TRYBROKEN=
+PORT_RUN_TESTS=0
 
-while getopts "b:B:o:cniIj:J:kNO:p:PSTvwz:" FLAG; do
+while getopts "b:B:o:ceniIj:J:kNO:p:PSTvwz:" FLAG; do
 	case "${FLAG}" in
 		b)
 			PACKAGE_FETCH_BRANCH="${OPTARG}"
@@ -95,6 +100,9 @@ while getopts "b:B:o:cniIj:J:kNO:p:PSTvwz:" FLAG; do
 			;;
 		c)
 			CONFIGSTR=1
+			;;
+		e)
+			PORT_RUN_TESTS=1
 			;;
 		o)
 			ORIGINSPEC=${OPTARG}


### PR DESCRIPTION
Add a -e flag to 'poudriere bulk' and 'poudriere testport' that runs 'make test-depends' and 'make test' for each port after the build and stage phases complete.

This helps catch missing TEST_DEPENDS by running port tests in a clean environment where only declared dependencies are installed.

Test failures are fatal by default; use -k to make them non-fatal (sets testfailure=2 and continues the build).

When combining -e with -t (PORTTESTING), the prestage filesystem snapshot is re-recorded after test-depends installs packages so that check_fs_violation at the package phase does not flag test dependencies as staging violations.