### PR TITLE
Fix remote deps name adjustment to allow pkg fetch

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -4653,7 +4653,7 @@ download_from_repo_check_pkg() {
 	    $1 == pkgbase {
 		    # Trim out PKG_NO_VERSION_FOR_DEPS missing version
 		    sub(/-\(null\)$/, "", $2)
-		    sub(/-$/, '' $2)
+		    sub(/-$/, "", $2)
 		    print $2
 		    printed=1
 	    }


### PR DESCRIPTION
Commit c51fe16 mishandled sub quoting and args, preventing name match required for pkg fetch.