### PR TITLE
Reject unsafe PKGNAME values before package staging

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -5445,6 +5445,9 @@ build_port() {
 	local JEXEC_SETSID
 	local -
 
+	pkgname_is_valid "${pkgname}" ||
+	    err 1 "build_port: Invalid PKGNAME '${pkgname}'"
+
 	_my_path mnt
 	_log_path log
 
@@ -6688,6 +6691,16 @@ _build_pkg_fp() {
 	fi
 }
 
+pkgname_is_valid() {
+	[ $# -eq 1 ] || eargs pkgname_is_valid pkgname
+	local pkgname="$1"
+
+	case "${pkgname}" in
+	""|"."|".."|*/*) return 1 ;;
+	esac
+	return 0
+}
+
 build_pkg() {
 	[ "$#" -eq 1 ] || eargs build_pkg pkgname
 	local pkgname="$1"
@@ -6704,6 +6717,9 @@ build_pkg() {
 	local elapsed now originspec status
 	local PORTTESTING build_reason
 	local -
+
+	pkgname_is_valid "${pkgname}" ||
+	    err 1 "build_pkg: Invalid PKGNAME '${pkgname}'"
 
 	_my_path mnt
 	_my_name name
@@ -7169,6 +7185,12 @@ deps_fetch_vars() {
 		err 1 "deps_fetch_vars: failed to get PKGNAME for ${COLOR_PORT}${originspec}${COLOR_RESET}"
 		;;
 	esac
+	if ! pkgname_is_valid "${_pkgname}"; then
+		msg_error "${COLOR_PORT}${origin}${COLOR_RESET} has invalid" \
+		    "PKGNAME '${_pkgname}'. Package names may not be empty," \
+		    "'.', '..', or contain '/'."
+		return 1
+	fi
 
 	# Validate PKGCATEGORY is proper to avoid:
 	# - Pkg not registering the dependency


### PR DESCRIPTION
Poudriere uses PKGNAME in host-side package staging paths. A port
Makefile can supply path separators or traversal components, causing
those operations to escape the staging directory.

Validate PKGNAME after metadata extraction and again before a build
worker uses it. This prevents unsafe port metadata from reaching
host filesystem operations.