### PR TITLE
Constrain package-output symlinks before host import

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -5443,6 +5443,7 @@ build_port() {
 	local max_execution_time allownetworking
 	local NEED_ROOT PREFIX MAX_FILES
 	local JEXEC_SETSID
+	local pkg_stage pkg_stage_real pkg_target
 	local -
 
 	pkgname_is_valid "${pkgname}" ||
@@ -5882,13 +5883,40 @@ build_port() {
 		esac
 	done
 
-	if [ -d "${PACKAGES}/.npkg/${pkgname}" ]; then
+	pkg_stage="${PACKAGES}/.npkg/${pkgname}"
+	if [ -d "${pkg_stage}" ]; then
 		# everything was fine we can copy the package to the package
 		# directory
-		find "${PACKAGES:?}/.npkg/${pkgname}" \
-		    -mindepth 1 \( -type f -or -type l \) |
+		# Only the pkg bootstrap needs package-manager compatibility links.
+		pkg_stage_real=
+		case "${port}" in
+		ports-mgmt/pkg|ports-mgmt/pkg-devel)
+			pkg_stage_real="$(realpath -q "${pkg_stage}")" ||
+			    err 1 "build_port: realpath ${pkg_stage}"
+			;;
+		esac
+		{
+			case "${pkg_stage_real}" in
+			"") ;;
+			*)
+				# Process links first so their targets are still in staging.
+				find "${pkg_stage}" -mindepth 1 -type l
+				;;
+			esac
+			find "${pkg_stage}" -mindepth 1 -type f
+		} |
 		    while mapfile_read_loop_redir pkg_path; do
-			pkg_file="${pkg_path#"${PACKAGES}/.npkg/${pkgname:?}"}"
+			if [ -L "${pkg_path}" ]; then
+				pkg_target="$(realpath -q "${pkg_path}" || :)"
+				case "${pkg_target}" in
+				"${pkg_stage_real:?}/"*) ;;
+				*)
+					msg_warn "Ignoring package symlink outside staging: ${pkg_path}"
+					continue
+					;;
+				esac
+			fi
+			pkg_file="${pkg_path#"${pkg_stage}"}"
 			pkg_base="${pkg_file%/*}"
 			mkdir -p "${PACKAGES:?}/${pkg_base:?}"
 			# rename as this is expected to be on the same


### PR DESCRIPTION
The package phase exposes a host-backed `/.npkg` directory to the jail build user. `build_port()` previously moved every file and symlink from that directory into the host package repository without checking the output layout or a symlink target.

An absolute symlink created by code running during a build has jail-relative meaning while `/.npkg` is mounted, but resolves on the host after import. It persists through the default atomic repository handoff. On the next `bulk` run, default unknown-file cleanup calls `realpath()` on the repository entry and `delete_pkg()` unlinks that resolved target as root.

A compromised upstream distfile or third-party build source can therefore cause arbitrary host-file deletion. No malicious ports metadata or ports-tree commit is required.

Only import direct `All/` and `Latest/` output entries, and reject symlinks whose resolved target is outside the per-build staging directory. Also restrict hashed-package cleanup to targets below the repository-owned `All/Hashed` directory, preserving legitimate `pkg repo --hash --symlink` cleanup without following an unexpected link.
