### PR TITLE
poudriered: retain queue while listing it

### DIFF
--- a/src/poudriered/poudriered.c
+++ b/src/poudriered/poudriered.c
@@ -646,7 +646,7 @@ client_exec(struct client *cl)
 				else
 					send_ok(cl, "reloaded");
 			} else if (!strcmp(ucl_object_tostring(c), "list")) {
-				send_object(cl, queue);
+				send_object(cl, ucl_object_ref(queue));
 			} else if (!strcmp(ucl_object_tostring(c), "status")) {
 				msg = ucl_object_typed_new(UCL_OBJECT);
 				ucl_object_insert_key(msg,


### PR DESCRIPTION
`client_exec()` passes Poudriered's global queue directly to
`send_object()` for `operation list`. `send_object()` releases the object
after serializing it, leaving the global queue pointer stale. A subsequent
list request can release that stale pointer again and terminate the daemon.

This requires a configuration that grants a non-root user `operation list`,
such as a monitoring role. That user can otherwise only use the intended
read-only API, but can deny service to the root-run queue daemon.

Take a temporary UCL reference when returning the queue so the global queue
remains valid.
