### PR TITLE
testport/bulk -i: Pass FLAVOR when looking up WRKDIR in interactive motd

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2904,7 +2904,7 @@ enter_interactive() {
 		cat >> "${MASTERMNT:?}/etc/motd" <<-EOF
 		ORIGIN:			${port:?}
 		PORTDIR:		${portdir:?}
-		WRKDIR:			$(injail make -C "${portdir:?}" -V WRKDIR)
+		WRKDIR:			$(injail make -C "${portdir:?}" ${flavor:+FLAVOR=${flavor}} -V WRKDIR)
 		EOF
 		case "${flavor:+set}" in
 		set)


### PR DESCRIPTION
The WRKDIR line queried `make -V WRKDIR` without FLAVOR, so a flavored port always reported its default flavor's work directory instead of the one actually built and installed -- e.g. audio/baresip built with FLAVOR=nox11 showed work-default. run-depends and install-package already pass ${flavor:+FLAVOR=${flavor}} a few lines above; do the same here.

Reproduced on misc/py-polars-runtime (FLAVOR=64 showing work-compat) and audio/baresip (FLAVOR=nox11 showing work-default); a port whose single auto-generated flavor happens to match the default (e.g. security/py-biscuit-python) masks the bug, which is likely why it went unnoticed.