### PR TITLE
jail, ports: Fix garbled output when checking out/updating with -v

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -760,11 +760,16 @@ install_from_vcs() {
 	if [ ${UPDATE} -eq 0 ]; then
 		case ${METHOD} in
 		svn*)
-			msg_n "Checking out the sources with ${METHOD}..."
+			# !! Any changes here should be considered for ports.sh too.
+			if [ -n "${quiet}" ]; then
+				msg_n "Checking out the sources with ${METHOD}..."
+			else
+				msg "Checking out the sources with ${METHOD}..."
+			fi
 			${SVN_CMD} ${quiet} checkout \
 			    ${SVN_FULLURL}/${VERSION} ${SRC_BASE} || \
 			    err 1 " fail"
-			echo " done"
+			[ -n "${quiet}" ] && echo " done"
 			if [ -n "${SRCPATCHFILE}" ]; then
 				msg_n "Patching the sources with ${SRCPATCHFILE}"
 				${SVN_CMD} ${quiet} patch ${SRCPATCHFILE} \
@@ -777,33 +782,46 @@ install_from_vcs() {
 			if [ -n "${SRCPATCHFILE}" ]; then
 				err 1 "Patch files not supported with git, please use feature branches"
 			fi
-			msg_n "Checking out the sources with ${METHOD}..."
+			if [ -n "${quiet}" ]; then
+				msg_n "Checking out the sources with ${METHOD}..."
+			else
+				msg "Checking out the sources with ${METHOD}..."
+			fi
 			${GIT_CMD} clone ${GIT_DEPTH} ${quiet} \
 			    ${VERSION:+-b ${VERSION}} ${GIT_FULLURL} \
 			    ${SRC_BASE} || \
 			    err 1 " fail"
-			echo " done"
+			[ -n "${quiet}" ] && echo " done"
 			# No support for patches, using feature branches is recommanded"
 			;;
 		esac
 	else
 		case ${METHOD} in
 		svn*)
-			msg_n "Updating the sources with ${METHOD}..."
+			# !! Any changes here should be considered for ports.sh too.
+			if [ -n "${quiet}" ]; then
+				msg_n "Updating the sources with ${METHOD}..."
+			else
+				msg "Updating the sources with ${METHOD}..."
+			fi
 			${SVN_CMD} upgrade ${SRC_BASE} 2>/dev/null || :
 			${SVN_CMD} ${quiet} update -r ${TORELEASE:-head} ${SRC_BASE} || err 1 " fail"
-			echo " done"
+			[ -n "${quiet}" ] && echo " done"
 			;;
 		git*)
 			# !! Any changes here should be considered for ports.sh too.
-			msg_n "Updating the sources with ${METHOD}..."
+			if [ -n "${quiet}" ]; then
+				msg_n "Updating the sources with ${METHOD}..."
+			else
+				msg "Updating the sources with ${METHOD}..."
+			fi
 			${GIT_CMD} -C ${SRC_BASE} pull --rebase ${quiet} || \
 			    err 1 " fail"
 			if [ -n "${TORELEASE}" ]; then
 				${GIT_CMD} -C ${SRC_BASE} checkout \
 				    ${quiet} "${TORELEASE}" || err 1 " fail"
 			fi
-			echo " done"
+			[ -n "${quiet}" ] && echo " done"
 			;;
 		esac
 	fi

--- a/src/share/poudriere/ports.sh
+++ b/src/share/poudriere/ports.sh
@@ -281,28 +281,37 @@ create)
 			    err 1 " fail"
 			;;
 		svn*)
+			# !! Any changes here should be considered for jail.sh too.
 			if [ ! -x "${SVN_CMD}" ]; then
 				err 1 "svn or svnlite not installed. Perhaps you need to 'pkg install subversion'"
 			fi
 
-			msg_n "Checking out the ports tree..."
+			if [ -n "${quiet}" ]; then
+				msg_n "Checking out the ports tree..."
+			else
+				msg "Checking out the ports tree..."
+			fi
 			[ "${BRANCH}" = "none" ] && BRANCH=""
 			${SVN_CMD} ${quiet} co \
 				${SVN_PRESERVE_TIMESTAMP} \
 				${SVN_FULLURL}${BRANCH:+/${BRANCH}} \
 				${PTMNT} || err 1 " fail"
-			echo " done"
+			[ -n "${quiet}" ] && echo " done"
 			;;
 		git*)
 			# !! Any changes here should be considered for jail.sh too.
 			if [ ! -x "${GIT_CMD}" ]; then
 				err 1 "Git is not installed. Perhaps you need to 'pkg install git'"
 			fi
-			msg_n "Cloning the ports tree..."
+			if [ -n "${quiet}" ]; then
+				msg_n "Cloning the ports tree..."
+			else
+				msg "Cloning the ports tree..."
+			fi
 			${GIT_CMD} clone ${GIT_DEPTH} ${quiet} \
 			    ${BRANCH:+-b ${BRANCH}} ${GIT_FULLURL} ${PTMNT} || \
 			    err 1 " fail"
-			echo " done"
+			[ -n "${quiet}" ] && echo " done"
 			;;
 		esac
 		pset ${PTNAME} method ${METHOD}
@@ -378,20 +387,29 @@ update)
 		echo " done"
 		;;
 	svn*)
-		msg_n "Updating portstree \"${PTNAME}\" with ${METHOD}..."
+		# !! Any changes here should be considered for jail.sh too.
+		if [ -n "${quiet}" ]; then
+			msg_n "Updating ports tree \"${PTNAME}\" with ${METHOD}..."
+		else
+			msg "Updating ports tree \"${PTNAME}\" with ${METHOD}..."
+		fi
 		${SVN_CMD} upgrade ${PORTSMNT:-${PTMNT}} 2>/dev/null || :
 		${SVN_CMD} ${quiet} update \
 			${SVN_PRESERVE_TIMESTAMP} \
 			${PORTSMNT:-${PTMNT}} || \
 		    err 1 " fail"
-		echo " done"
+		[ -n "${quiet}" ] && echo " done"
 		;;
 	git*)
 		# !! Any changes here should be considered for jail.sh too.
-		msg_n "Updating portstree \"${PTNAME}\" with ${METHOD}..."
+		if [ -n "${quiet}" ]; then
+			msg_n "Updating ports tree \"${PTNAME}\" with ${METHOD}..."
+		else
+			msg "Updating ports tree \"${PTNAME}\" with ${METHOD}..."
+		fi
 		${GIT_CMD} -C ${PORTSMNT:-${PTMNT}} pull --rebase ${quiet} || \
 		    err 1 " fail"
-		echo " done"
+		[ -n "${quiet}" ] && echo " done"
 		;;
 	null|none) msg "Not updating portstree \"${PTNAME}\" with method ${METHOD}" ;;
 	*)


### PR DESCRIPTION
The svn/git checkout and update paths in both ports.sh and jail.sh's install_from_vcs() used msg_n() followed by the raw command's own output and a glued-on " done", relying on the command producing no output of its own. With -v that assumption is wrong: quiet mode is disabled, so svn/git's own progress output gets appended directly onto the unterminated header line, and " done" gets glued onto the tool's own last output line instead of starting a new one.

Use msg() instead of msg_n() when not running quiet, so the header gets its own line before the command's output, and drop the redundant trailing "done" for that case since the tool's own output already signals completion. Apply the same fix to jail.sh, which had the identical pattern for fetching/updating jail sources, and add the existing "!! Any changes here should be considered for ... too." cross-reference comment to the svn cases in both files so the two code paths stay in sync going forward.

Fixes #1351